### PR TITLE
Adding pixel mask task to main drp script

### DIFF
--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -241,16 +241,24 @@ def reduce_frame(filename: str, camera: str = None, mjd: int = None,
     flavor = flavor or fkwargs.get('imagetyp')
     flavor = 'fiberflat' if flavor == 'flat' else flavor
 
-    if not master:
-        # check master frames
-        masters = find_masters("object", camera)
-        mbias = masters.get('bias')
-        mdark = masters.get('dark')
-        mpixflat = masters.get('pixelflat')
-        mflat = masters.get('flat')
-        marc = masters.get('arc')
-        mpixmask = masters.get('pixmask')
+    # check master frames
+    masters = find_masters("object", camera)
+    mbias = masters.get('bias')
+    mdark = masters.get('dark')
+    mpixflat = masters.get('pixelflat')
+    mflat = masters.get('flat')
+    marc = masters.get('arc')
+    mpixmask = masters.get('pixmask')
 
+    # log the master frames
+    log.info(f'Using master bias: {mbias}')
+    log.info(f'Using master dark: {mdark}')
+    log.info(f'Using master pixel flat: {mpixflat}')
+    log.info(f'Using master flat: {mflat}')
+    log.info(f'Using master arc: {marc}')
+    log.info(f'Using master pixel mask: {mpixmask}')
+
+    if not master:
         # create pixel mask if needed
         if flavor not in {'bias', 'dark', 'pixelflat'} and mpixmask is None:
             mpixmask = path.full('lvm_master', kind='mpixmask', drpver=drpver, mjd=mjd, tileid=tileid,
@@ -258,14 +266,6 @@ def reduce_frame(filename: str, camera: str = None, mjd: int = None,
             create_pixelmask(in_bias=mbias, in_dark=mdark, in_pixelflat=mflat, out_mask=mpixmask)
 
             get_master_metadata(overwrite=True)
-
-        # log the master frames
-        log.info(f'Using master bias: {mbias}')
-        log.info(f'Using master dark: {mdark}')
-        log.info(f'Using master pixel flat: {mpixflat}')
-        log.info(f'Using master flat: {mflat}')
-        log.info(f'Using master arc: {marc}')
-        log.info(f'Using master pixel mask: {mpixmask}')
 
         # preprocess the frames
         log.info('--- Preprocessing raw frame ---')

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -258,6 +258,7 @@ def reduce_frame(filename: str, camera: str = None, mjd: int = None,
     log.info(f'Using master arc: {marc}')
     log.info(f'Using master pixel mask: {mpixmask}')
 
+    # only run these steps for individual exposures
     if not master:
         # create pixel mask if needed
         if flavor not in {'bias', 'dark', 'pixelflat'} and mpixmask is None:


### PR DESCRIPTION
This branch adds the `create_pixelmask` task to the main `run_drp` script. Some general changes are:

1. Reordering where master paths are defined
2. Added `mpixmask` master path
3. Producing pixel masks only after reducing bias, darks and pixelflats and no pixelmask was found
4. Adding `in_mask=mpixmask` to `preproc_raw_frame` task

This feature will help significantly improve flat and arc reductions.