### PR TITLE
Adds cli option for regenerating metadata manually

### DIFF
--- a/bin/drp
+++ b/bin/drp
@@ -4,12 +4,13 @@
 
 import click
 import cloup
-from cloup.constraints import mutually_exclusive, RequireExactly
+from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
 
 from astropy.io import fits
 from lvmdrp.functions.run_drp import run_drp, get_config_options, reduce_file
 from lvmdrp.functions.imageMethod import preproc_raw_frame
 from lvmdrp.functions.skyMethod import installESOSky_drp, configureSkyModel_drp
+from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
 
 
 @click.group('drp', short_help='CLI for the LVM data reduction')
@@ -50,6 +51,7 @@ def run(mjd, mjd_list, mjd_range, skip_bd, arc, flat, only_bd, only_cal, only_sc
     run_drp(mjd=mjd, flat=flat, arc=arc, skip_bd=skip_bd, only_bd=only_bd,
             only_cal=only_cal, only_sci=only_sci, camera=camera, spec=spec,
             expnum=expnum, quick=quick)
+
 
 cli.add_command(run)
 
@@ -107,6 +109,28 @@ def sky_configure(library, multiscat):
 
 
 cli.add_command(skycli)
+
+
+@click.group('metadata', short_help='Run routines related to frame metadata')
+def metacli():
+    pass
+
+
+@cloup.command('regenerate', short_help='Regenerate the frames metadata file')
+@click.option('-m', '--mjd', type=int, help='the MJD to regenerate the metadata for')
+@click.option('-a', '--masters', is_flag=True, default=False, help='Flag to regenerate the masters metadata')
+@cloup.constraint(If(~IsSet('masters'), then=RequireExactly(1)), ['mjd'])
+def regen(mjd: int, masters: bool):
+    """ Regenerate the raw or master frames metadata file """
+    if masters:
+        get_master_metadata(overwrite=True)
+    else:
+        get_frames_metadata(mjd=mjd, overwrite=True)
+
+
+metacli.add_command(regen)
+
+cli.add_command(metacli)
 
 
 if __name__ == "__main__":

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -658,7 +658,7 @@ def run_drp(mjd: Union[int, str, list], bias: bool = False, dark: bool = False,
         return
 
     # find files
-    frames = get_frames_metadata(mjd=mjd, overwrite=True)
+    frames = get_frames_metadata(mjd=mjd)
     sub = frames.copy()
 
     # remove bad or test quality frames


### PR DESCRIPTION
This PR adds a new cli command for regenerating the raw or master frames metadata manually.  This is to enable manual updates without causing it to constantly re-run on every pipeline run for the full reductions.  The quick reductions at LCO will be handled slightly differently than through the `run_drp` method. 