### PR TITLE
Adds method for combining spectrographs into single new

### DIFF
--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -2724,7 +2724,6 @@ def DAR_registerSDSS_drp(
         plt.show()
 
 
-@drop_missing_input_paths(["in_rss"])
 def join_spec_channels(in_rss: list, out_rss: list, parallel: str = "auto"):
     """combine the given RSS list through the overlaping wavelength range
 

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -1020,7 +1020,7 @@ def combine_spectrographs(tileid: int, mjd: int, expnum: int) -> fits.HDUList:
     # update the primary header
     hdr['SPEC'] = ', '.join([i.split('-')[2] for i in files])
     hdr['FILENAME'] = pathlib.Path(cframe).name
-    hdr['VERSDRP'] = drpver
+    hdr['DRPVER'] = drpver
 
     # remove the wcs from the primary header; add it to flux header
     [hdr.pop(i, None) for i in wcs.to_header().keys()]

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -1025,9 +1025,15 @@ def combine_spectrographs(tileid: int, mjd: int, expnum: int) -> fits.HDUList:
     # remove the wcs from the primary header; add it to flux header
     [hdr.pop(i, None) for i in wcs.to_header().keys()]
 
+    # create new hdr for flux extension
+    newhdr = {'BUNIT': hdr.pop("BUNIT", None)}
+    newhdr['BSCALE'] = hdr.pop("BSCALE", None)
+    newhdr['BZERO'] = hdr.pop("BZERO", None)
+    newhdr |= wcs.to_header()
+
     # create the new FITS file
     prim = fits.PrimaryHDU(header=hdr)
-    flux = fits.ImageHDU(flux_data, name='FLUX', header=wcs.to_header())
+    flux = fits.ImageHDU(flux_data, name='FLUX', header=newhdr)
     err = fits.ImageHDU(err_data, name='ERROR')
     mask = fits.ImageHDU(mask_data, name='MASK')
     fwhm = fits.ImageHDU(fwhm_data, name='FWHM')


### PR DESCRIPTION
This PR adds a new function and pipeline step for combining the spectographs into a single file.  This combines the camera-combined ancillrary `lvm-object-sp[x]-[expnum].fits` files (3 files), for a given exposure, into the output `lvm-CFrame-[expnum].fits` file which will be input into the sky subtraction module.    The data are stacked as [sp1, sp2, sp3] which makes the data ordered "bottom-to-top", i.e. the 0-index array element is the start of sp1 fibers. 

The extensions of the file are:
- PRIMARY - primary header
- FLUX - the flux data (formerly data in extension 0)
- ERROR - the error data (until we switch it to IVAR) 
- MASK - the pixel mask (formerly BADPIX)
- WAVE - the 1d wavelength array
- FWHM - the measured FWHM (formerly INSTFWHM)
- SLITMAP - the full fibermap

