### PR TITLE
Fixing double precision in reduction operations and products

### DIFF
--- a/python/lvmdrp/core/cube.py
+++ b/python/lvmdrp/core/cube.py
@@ -295,6 +295,15 @@ class Cube(Header, PositionTable):
         extension_error : int (0, 1, or 2), optional with default: None
             Number of the FITS extension containing the errors for the values
         """
+        # convert all to single precision
+        self._data = self._data.astype("float32")
+        if self._error is not None:
+            self._error = self._error.astype("float32")
+        if self._error_weight is not None:
+            self._error_weight = self._error_weight.astype("float32")
+        if self._wave is not None:
+            self._wave = self._wave.astype("float32")
+
         hdus = [None, None, None, None, None, None]  # create empty list for hdu storage
 
         # create primary hdus and image hdus
@@ -353,7 +362,7 @@ class Cube(Header, PositionTable):
         for i in range(len(hdus)):
             try:
                 hdus.remove(None)
-            except:
+            except ValueError:
                 break
 
         if len(hdus) > 0:

--- a/python/lvmdrp/core/cube.py
+++ b/python/lvmdrp/core/cube.py
@@ -67,9 +67,9 @@ class Cube(Header, PositionTable):
             else:
                 error = None
             if data.dtype == numpy.float64:
-                data.astype(numpy.float32)
+                data = data.astype(numpy.float32)
             if error is not None and error.dtype == numpy.float64:
-                error.astype(numpy.float32)
+                error = error.astype(numpy.float32)
 
             cube = Cube(
                 wave=self._wave,

--- a/python/lvmdrp/core/fiberrows.py
+++ b/python/lvmdrp/core/fiberrows.py
@@ -686,32 +686,32 @@ class FiberRows(Header, PositionTable):
             and extension_error is None
             and extension_coeffs is None
         ):
-            self._data = hdu[0].data
+            self._data = hdu[0].data.astype("float32")
             self._fibers = self._data.shape[0]
             self._pixels = numpy.arange(self._data.shape[1])
             self.setHeader(hdu[0].header)
             if len(hdu) > 1:
                 for i in range(1, len(hdu)):
                     if hdu[i].header["EXTNAME"].split()[0] == "ERROR":
-                        self._error = hdu[i].data
+                        self._error = hdu[i].data.astype("float32")
                     elif hdu[i].header["EXTNAME"].split()[0] == "BADPIX":
-                        self._mask = hdu[i].data.astype(bool)
+                        self._mask = hdu[i].data.astype("bool")
                         self._good_fibers = numpy.where(numpy.sum(self._mask, axis=1) != self._data.shape[1])[0]
                     elif hdu[i].header["EXTNAME"].split()[0] == "COEFFS":
-                        self._coeffs = hdu[i].data
+                        self._coeffs = hdu[i].data.astype("float32")
 
         else:
             if extension_data is not None:
-                self._data = hdu[extension_data].data
+                self._data = hdu[extension_data].data.astype("float32")
                 self._fibers = self._data.shape[0]
                 self._pixels = numpy.arange(self._data.shape[1])
             if extension_mask is not None:
-                self._mask = hdu[extension_mask].data.astype(bool)
+                self._mask = hdu[extension_mask].data.astype("bool")
                 self._good_fibers = numpy.where(numpy.sum(self._mask, axis=1) != self._data.shape[1])[0]
             if extension_error is not None:
-                self._error = hdu[extension_error].data
+                self._error = hdu[extension_error].data.astype("float32")
             if extension_coeffs is not None:
-                self._coeffs = hdu[extension_coeffs].data
+                self._coeffs = hdu[extension_coeffs].data.astype("float32")
         
         hdu.close()
         

--- a/python/lvmdrp/core/fiberrows.py
+++ b/python/lvmdrp/core/fiberrows.py
@@ -750,6 +750,13 @@ class FiberRows(Header, PositionTable):
         extension_error : int (0, 1, or 2), optional with default: None
             Number of the FITS extension containing the errors for the values
         """
+        # convert all to single precision
+        self._data = self._data.astype("float32")
+        if self._error is not None:
+            self._error = self._error.astype("float32")
+        if self._coeffs is not None:
+            self._coeffs = self._coeffs.astype("float32")
+
         hdus = [None, None, None, None]
 
         # create primary hdus and image hdus
@@ -813,9 +820,7 @@ class FiberRows(Header, PositionTable):
             del hdu[0]._header["HISTORY"]
         except KeyError:
             pass
-        hdu.writeto(
-            filename, output_verify="silentfix", overwrite=True
-        )  # write FITS file to disc
+        hdu.writeto(filename, output_verify="silentfix", overwrite=True)
 
     def measureArcLines(
         self,

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -1017,12 +1017,12 @@ class Image(Header):
             and extension_frames is None
             and extension_slitmap is None
         ):
-            self._data = hdu[0].data
+            self._data = hdu[0].data.astype("float32")
             self._dim = self._data.shape  # set dimension
             if len(hdu) > 1:
                 for i in range(1, len(hdu)):
                     if hdu[i].header["EXTNAME"].split()[0] == "ERROR":
-                        self._error = hdu[i].data
+                        self._error = hdu[i].data.astype("float32")
                     elif hdu[i].header["EXTNAME"].split()[0] == "BADPIX":
                         self._mask = hdu[i].data.astype("bool")
                     elif hdu[i].header["EXTNAME"].split()[0] == "FRAMES":
@@ -1032,7 +1032,7 @@ class Image(Header):
 
         else:
             if extension_data is not None:
-                self._data = hdu[extension_data].data  # take data
+                self._data = hdu[extension_data].data.astype("float32")
                 self._dim = self._data.shape  # set dimension
 
             if extension_mask is not None:
@@ -1040,7 +1040,7 @@ class Image(Header):
                 self._dim = self._mask.shape  # set dimension
 
             if extension_error is not None:
-                self._error = hdu[extension_error].data  # take data
+                self._error = hdu[extension_error].data.astype("flaoat32")
                 self._dim = self._error.shape  # set dimension
             if extension_frames is not None:
                 self._individual_frames = Table(hdu[extension_frames].data)
@@ -1143,9 +1143,7 @@ class Image(Header):
                     pass
                 hdu[0].update_header()
 
-        hdu.writeto(
-            filename, output_verify="silentfix", overwrite=True
-        )  # write FITS file to disc
+        hdu.writeto(filename, output_verify="silentfix", overwrite=True)
 
     def computePoissonError(self, rdnoise):
         self._error = numpy.zeros_like(self._data)

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -1072,6 +1072,11 @@ class Image(Header):
         extension_error : int (0, 1, or 2), optional with default: None
             Number of the FITS extension containing the errors for the values
         """
+        # convert all to single precision
+        self._data = self._data.astype("float32")
+        if self._error is not None:
+            self._error = self._error.astype("float32")
+
         hdus = [None, None, None, None, None]  # create empty list for hdu storage
 
         # create primary hdus and image hdus

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -550,6 +550,15 @@ class RSS(FiberRows):
         extension_error : int (0, 1, or 2), optional with default: None
             Number of the FITS extension containing the errors for the values
         """
+        # convert all to single precision
+        self._data = self._data.astype(numpy.float32)
+        if self._error is not None:
+            self._error = self._error.astype(numpy.float32)
+        if self._wave is not None:
+            self._wave = self._wave.astype(numpy.float32)
+        if self._inst_fwhm is not None:
+            self._inst_fwhm = self._inst_fwhm.astype(numpy.float32)
+
         hdus = [None, None, None, None, None, None, None]  # create empty list for hdu storage
 
         # create primary hdus and image hdus

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -222,9 +222,9 @@ class RSS(FiberRows):
             else:
                 mask = self._mask
             if data.dtype == numpy.float64:
-                data.astype(numpy.float32)
+                data = data.astype(numpy.float32)
             if error is not None and error.dtype == numpy.float64:
-                error.astype(numpy.float32)
+                error = error.astype(numpy.float32)
             rss = RSS(
                 data=data,
                 error=error,
@@ -266,9 +266,9 @@ class RSS(FiberRows):
                 mask = self._mask
 
             if data.dtype == numpy.float64:
-                data.astype(numpy.float32)
+                data = data.astype(numpy.float32)
             if error is not None and error.dtype == numpy.float64:
-                error.astype(numpy.float32)
+                error = error.astype(numpy.float32)
             rss = RSS(
                 data=data,
                 error=error,
@@ -298,7 +298,7 @@ class RSS(FiberRows):
                 else:
                     data = self._data
                 if data.dtype == numpy.float64:
-                    data.astype(numpy.float32)
+                    data = data.astype(numpy.float32)
 
                 rss = RSS(
                     data=data,
@@ -322,9 +322,9 @@ class RSS(FiberRows):
                 else:
                     error = self._error
                 if data.dtype == numpy.float64:
-                    data.astype(numpy.float32)
+                    data = data.astype(numpy.float32)
                 if error is not None and error.dtype == numpy.float64:
-                    error.astype(numpy.float32)
+                    error = error.astype(numpy.float32)
                 rss = RSS(
                     data=data,
                     error=error,
@@ -481,20 +481,20 @@ class RSS(FiberRows):
             and extension_fwhm is None
             and extension_slitmap is None
         ):
-            self._data = hdu[0].data
+            self._data = hdu[0].data.astype("float32")
             self.setHeader(header=hdu[0].header, origin=file)
             self.createWavefromHdr(logwave=logwave)
             if len(hdu) > 1:
                 for i in range(1, len(hdu)):
                     if hdu[i].header["EXTNAME"].split()[0] == "ERROR":
-                        self._error = hdu[i].data
+                        self._error = hdu[i].data.astype("float32")
                     if hdu[i].header["EXTNAME"].split()[0] == "BADPIX":
                         self._mask = hdu[i].data.astype("bool")
                         self._good_fibers = numpy.where(numpy.sum(self._mask, axis=1) != self._data.shape[1])[0]
                     if hdu[i].header["EXTNAME"].split()[0] == "WAVE":
-                        self.setWave(hdu[i].data)
+                        self.setWave(hdu[i].data.astype("float32"))
                     if hdu[i].header["EXTNAME"].split()[0] == "INSTFWHM":
-                        self.setInstFWHM(hdu[i].data)
+                        self.setInstFWHM(hdu[i].data.astype("float32"))
                     if hdu[i].header["EXTNAME"].split()[0] == "POSTABLE":
                         self.loadFitsPosTable(hdu[i])
                     if hdu[i].header["EXTNAME"].split()[0] == "SLITMAP":
@@ -503,16 +503,16 @@ class RSS(FiberRows):
             if extension_hdr is not None:
                 self.setHeader(hdu[extension_hdr].header, origin=file)
             if extension_data is not None:
-                self._data = hdu[extension_data].data
+                self._data = hdu[extension_data].data.astype("float32")
             if extension_mask is not None:
                 self._mask = hdu[extension_mask].data
                 self._good_fibers = numpy.where(numpy.sum(self._mask, axis=1) != self._data.shape[1])[0]
             if extension_error is not None:
-                self._error = hdu[extension_error].data
+                self._error = hdu[extension_error].data.astype("float32")
             if extension_wave is not None:
-                self.setWave(hdu[extension_wave].data)
+                self.setWave(hdu[extension_wave].data.astype("float32"))
             if extension_fwhm is not None:
-                self.setInstFWHM(hdu[extension_fwhm].data)
+                self.setInstFWHM(hdu[extension_fwhm].data.astype("float32"))
             if extension_slitmap is not None:
                 self.setSlitmap(Table(hdu[extension_slitmap].data))
         

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -854,6 +854,15 @@ class Spectrum1D(Header):
         extension_error : int (0, 1, or 2), optional with default: None
             Number of the FITS extension containing the errors for the values
         """
+        # convert all to single precision
+        self._data = self._data.astype("float32")
+        if self._error is not None:
+            self._error = self._error.astype("float32")
+        if self._wave is not None:
+            self._wave = self._wave.astype("float32")
+        if self._inst_fwhm is not None:
+            self._inst_fwhm = self._inst_fwhm.astype("float32")
+
         hdus = [None, None, None, None, None]  # create empty list for hdu storage
 
         # create primary hdus and image hdus

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -700,7 +700,7 @@ class Spectrum1D(Header):
             if self._error is not None:
                 error = self._error * other
                 if error.dtype == numpy.float64 or error.dtype == numpy.dtype(">f8"):
-                    error.astype(numpy.float32)
+                    error = error.astype(numpy.float32)
             else:
                 error = None
             mask = self._mask

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -2924,10 +2924,10 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
     masks_f = [interpolate.interp1d(rss._wave, rss._mask, axis=1, kind="nearest", bounds_error=False, fill_value=0) for rss in rsss]
     lsfs_f = [interpolate.interp1d(rss._wave, rss._inst_fwhm, axis=1, bounds_error=False, fill_value=numpy.nan) for rss in rsss]
     # evaluate interpolators
-    fluxes = numpy.asarray([f(new_wave) for f in fluxes_f])
-    errors = numpy.asarray([f(new_wave) for f in errors_f])
-    masks = numpy.asarray([f(new_wave) for f in masks_f])
-    lsfs = numpy.asarray([f(new_wave) for f in lsfs_f])
+    fluxes = numpy.asarray([f(new_wave).astype("float32") for f in fluxes_f])
+    errors = numpy.asarray([f(new_wave).astype("float32") for f in errors_f])
+    masks = numpy.asarray([f(new_wave).astype("uint8") for f in masks_f])
+    lsfs = numpy.asarray([f(new_wave).astype("float32") for f in lsfs_f])
 
     # define weights for channel combination
     vars = errors ** 2
@@ -2943,7 +2943,7 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
     new_data = bn.nansum(fluxes * weights, axis=0)
     new_inst_fwhm = bn.nansum(lsfs * weights, axis=0)
     new_error = numpy.sqrt(bn.nansum(vars, axis=0))
-    new_mask = numpy.sum(masks, axis=0).astype(bool)
+    new_mask = numpy.sum(masks, axis=0).astype("bool")
 
     # create RSS
     log.info(f"writing output RSS to {os.path.basename(out_rss)}")

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -1004,7 +1004,7 @@ def combine_spectrographs(tileid: int, mjd: int, expnum: int) -> fits.HDUList:
     # build the wavelength axis
     wcs = WCS(hdr)
     n_wave = hdr['NAXIS1']
-    wl = wcs.spectral.all_pix2world(np.arange(n_wave), 0)[0]
+    wl = wcs.spectral.all_pix2world(np.arange(n_wave), 0)[0].astype("float32")
     wave = fits.ImageHDU((wl * u.m).to(u.angstrom).value, name='WAVE')
 
     # get total number of fibers from the fibermap

--- a/python/lvmdrp/functions/skyMethod.py
+++ b/python/lvmdrp/functions/skyMethod.py
@@ -1439,10 +1439,10 @@ def interpolate_sky(in_rss: str, out_sky: str, out_rss: str = None, which: str =
 
     fig, axs = create_subplots(to_display=display_plots, figsize=(20,10), nrows=2, ncols=1, sharex=True)
     axs[0].scatter(swave, ssky, s=1, color="tab:blue", label="super sky")
-    axs[0].plot(swave[~smask], f_data(swave[~smask]), lw=1, color="k", label="spline")
+    axs[0].plot(swave[~smask], f_data(swave[~smask]).astype("float32"), lw=1, color="k", label="spline")
 
     # plot residuals
-    residuals = (f_data(sky_wave) - sky_data)
+    residuals = (f_data(sky_wave).astype("float32") - sky_data)
     residuals = residuals.flatten()
     axs[1].scatter(sky_wave.flatten(), residuals)
     axs[1].axhline(ls="--", lw=1, color="k")
@@ -1460,8 +1460,8 @@ def interpolate_sky(in_rss: str, out_sky: str, out_rss: str = None, which: str =
     # interpolated sky
     dlambda = np.diff(rss._wave, axis=1)
     dlambda = np.column_stack((dlambda, dlambda[:, -1]))
-    new_sky = f_data(rss._wave) * dlambda
-    new_error = np.sqrt(f_error(rss._wave)) * dlambda
+    new_sky = f_data(rss._wave).astype("float32") * dlambda
+    new_error = np.sqrt(f_error(rss._wave).astype("float32")) * dlambda
     new_mask = f_mask(rss._wave).astype(bool)
     # update mask with new bad pixels
     # new_mask |= rss._mask


### PR DESCRIPTION
Fixing remaining double precision operations and I/O methods. Main changes are:

- Fixing `loadFitsData` methods to convert data to `float32`
- Fixing outputs from interpolation routines to be `float32`
- Fixing output from `all_pix2world` method to be `float32`
- Making sure all `writeFitsData` write `float32`