### PR TITLE
New frame combination scheme

### DIFF
--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -11,7 +11,7 @@ from lvmdrp.core.constants import CONFIG_PATH
 from lvmdrp.core.apertures import Aperture
 from lvmdrp.core.cube import Cube
 from lvmdrp.core.fiberrows import FiberRows
-from lvmdrp.core.header import Header, combineHdr
+from lvmdrp.core.header import Header
 from lvmdrp.core.positionTable import PositionTable
 from lvmdrp.core.spectrum1d import Spectrum1D
 
@@ -2184,61 +2184,3 @@ def loadRSS(infile, extension_data=None, extension_mask=None, extension_error=No
     )
 
     return rss
-
-
-def glueRSS(infiles, outfile):
-    for i in range(len(infiles)):
-        rss = loadRSS(infiles[i])
-        hdrs = []
-        if i == 0:
-            data_out = rss._data
-            if rss._error is not None:
-                error_out = rss._error
-            if rss._mask is not None:
-                mask_out = rss._mask
-            if rss._wave is not None:
-                wave_out = rss._wave
-            if rss._inst_fwhm is not None:
-                fwhm_out = rss._inst_fwhm
-            if rss._sky is not None:
-                sky_out = rss._sky
-            if rss._header is not None:
-                hdrs.append(Header(rss.getHeader()))
-        else:
-            data_out = numpy.concatenate((data_out, rss._data), axis=1)
-            if rss._error is not None:
-                error_out = numpy.concatenate((error_out, rss._error), axis=1)
-            else:
-                error_out = None
-            if rss._mask is not None:
-                mask_out = numpy.concatenate((mask_out, rss._mask), axis=1)
-            else:
-                mask_out = None
-            if rss._wave is not None:
-                wave_out = numpy.concatenate((wave_out, rss._wave), axis=1)
-            else:
-                wave_out = None
-            if rss._inst_fwhm is not None:
-                fwhm_out = numpy.concatenate((fwhm_out, rss._inst_fwhm), axis=1)
-            else:
-                fwhm_out = None
-            if rss._sky is not None:
-                sky_out = numpy.concatenate((sky_out, rss._sky), axis=1)
-            else:
-                sky_out = None
-            if rss._header is not None:
-                hdrs.append(Header(rss.getHeader()))
-    if len(hdrs) > 0:
-        hdr_out = combineHdr(hdrs)
-    else:
-        hdr_out = None
-    rss_out = RSS(
-        wave=wave_out,
-        data=data_out,
-        error=error_out,
-        mask=mask_out,
-        inst_fwhm=fwhm_out,
-        sky=sky_out,
-        header=hdr_out.getHeader(),
-    )
-    rss_out.writeFitsData(outfile)

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -21,12 +21,13 @@ from scipy import interpolate, ndimage
 
 from lvmdrp.utils.decorators import skip_on_missing_input_path, drop_missing_input_paths, skip_if_drpqual_flags
 from lvmdrp.core.constants import CONFIG_PATH, ARC_LAMPS
+from lvmdrp.core.header import Header, combineHdr
 from lvmdrp.core.cube import Cube
 from lvmdrp.core.fiberrows import FiberRows
 from lvmdrp.core.image import loadImage
 from lvmdrp.core.passband import PassBand
 from lvmdrp.core.plot import plt, create_subplots, save_fig, plot_wavesol_residuals, plot_wavesol_coeffs
-from lvmdrp.core.rss import RSS, _read_pixwav_map, glueRSS, loadRSS
+from lvmdrp.core.rss import RSS, _read_pixwav_map, loadRSS
 from lvmdrp.core.spectrum1d import Spectrum1D, wave_little_interpol, _spec_from_lines, _cross_match
 from lvmdrp.external import ancillary_func
 from lvmdrp.utils import flatten
@@ -1710,18 +1711,95 @@ def combineRSS_drp(in_rsss, out_rss, method="mean"):
     combined_rss.writeFitsData(out_rss)
 
 
-def glueRSS_drp(rsss, out_rss):
-    """concatenates the given RSS list to a single RSS
+def stack_rss(in_rsss: List[str], out_rss: str, axis: int = 0) -> RSS:
+    """stacks a list of RSS objects along a given axis
 
     Parameters
     ----------
-    rsss : array_like
+    in_rsss : List[str]
         list of RSS file paths
     out_rss : str
         output RSS file path
+    axis : int, optional
+        axis along which to stack the RSS objects, by default 0
+
+    Returns
+    -------
+    RSS
+        stacked RSS object
     """
-    list_rss = rsss.split(",")
-    glueRSS(list_rss, out_rss)
+    for i in range(len(in_rsss)):
+        rss = loadRSS(in_rsss[i])
+        hdrs = []
+        if i == 0:
+            data_out = rss._data
+            if rss._error is not None:
+                error_out = rss._error
+            if rss._mask is not None:
+                mask_out = rss._mask
+            if rss._wave is not None:
+                wave_out = rss._wave
+            if rss._inst_fwhm is not None:
+                fwhm_out = rss._inst_fwhm
+            if rss._sky is not None:
+                sky_out = rss._sky
+            if rss._sky_error is not None:
+                sky_error_out = rss._sky_error
+            if rss._header is not None:
+                hdrs.append(Header(rss.getHeader()))
+        else:
+            data_out = numpy.concatenate((data_out, rss._data), axis=axis)
+            if rss._wave is not None:
+                if len(wave_out.shape) == 2 and len(rss._wave.shape) == 2:
+                    wave_out = numpy.concatenate((wave_out, rss._wave), axis=axis)
+                elif len(wave_out.shape) == 1 and len(rss._wave.shape) == 1 and numpy.isclose(wave_out, rss._wave).all():
+                    wave_out = wave_out
+                else:
+                    raise ValueError(f"Cannot concatenate wavelength arrays of different shapes: {wave_out.shape} and {rss._wave.shape} or inhomogeneous wavelength arrays")
+            else:
+                wave_out = None
+            if rss._inst_fwhm is not None:
+                if len(fwhm_out.shape) == 2 and len(rss._inst_fwhm.shape) == 2:
+                    fwhm_out = numpy.concatenate((fwhm_out, rss._inst_fwhm), axis=axis)
+                elif len(fwhm_out.shape) == 1 and len(rss._inst_fwhm.shape) == 1 and numpy.isclose(fwhm_out, rss._inst_fwhm).all():
+                    fwhm_out = fwhm_out
+                else:
+                    raise ValueError(f"Cannot concatenate FWHM arrays of different shapes: {fwhm_out.shape} and {rss._inst_fwhm.shape} or inhomogeneous FWHM arrays")
+            else:
+                fwhm_out = None
+            if rss._error is not None:
+                error_out = numpy.concatenate((error_out, rss._error), axis=axis)
+            else:
+                error_out = None
+            if rss._mask is not None:
+                mask_out = numpy.concatenate((mask_out, rss._mask), axis=axis)
+            else:
+                mask_out = None
+            if rss._sky is not None:
+                sky_out = numpy.concatenate((sky_out, rss._sky), axis=axis)
+            else:
+                sky_out = None
+            if rss._sky_error is not None:
+                sky_error_out = numpy.concatenate((sky_error_out, rss._sky_error), axis=axis)
+            if rss._header is not None:
+                hdrs.append(Header(rss.getHeader()))
+    if len(hdrs) > 0:
+        hdr_out = combineHdr(hdrs)
+    else:
+        hdr_out = None
+    rss_out = RSS(
+        wave=wave_out,
+        data=data_out,
+        error=error_out,
+        mask=mask_out,
+        inst_fwhm=fwhm_out,
+        sky=sky_out,
+        sky_error=sky_error_out,
+        header=hdr_out.getHeader(),
+    )
+    rss_out.writeFitsData(out_rss)
+
+    return rss_out
 
 
 def apertureFluxRSS_drp(

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -3043,7 +3043,7 @@ def DAR_registerSDSS_drp(
         plt.show()
 
 
-def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True):
+def join_spec_channels(in_rsss: List[str], out_rss: str, use_weights: bool = True):
     """combine the given RSS list through the overlaping wavelength range
 
     Run once per exposure, for one spectrograph at a time.
@@ -3052,7 +3052,7 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
 
     Parameters
     ----------
-    in_rss : array_like
+    in_rsss : array_like
         list of RSS file paths for each spectrograph channel
     out_rss : str
         output RSS file path
@@ -3064,8 +3064,8 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
     """
 
     # read all three channels
-    log.info(f"loading RSS files: {in_rss}")
-    rsss = [loadRSS(rss_path) for rss_path in in_rss]
+    log.info(f"loading RSS files: {', '.join([os.path.basename(in_rss) for in_rss in in_rsss])}")
+    rsss = [loadRSS(in_rss) for in_rss in in_rsss]
     # set masked pixels to NaN
     [rss.apply_pixelmask() for rss in rsss]
 
@@ -3075,7 +3075,7 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
     # compute the combined wavelengths
     new_wave = wave_little_interpol(waves)
     sampling = numpy.diff(new_wave)
-    log.info(f"new wavelength sampling: min = {sampling.min()}, max = {sampling.max()}")
+    log.info(f"new wavelength sampling: min = {sampling.min():.2f}, max = {sampling.max():.2f}")
 
     # define interpolators
     log.info("interpolating RSS data in new wavelength array")

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -3116,7 +3116,6 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
         new_sky_error = numpy.sqrt(bn.nanmean(sky_errors ** 2, axis=0))
 
     # create RSS
-    log.info(f"writing output RSS to {os.path.basename(out_rss)}")
     new_hdr = rsss[0]._header.copy()
     new_hdr["CCD"] = ",".join([rss._header["CCD"] for rss in rsss])
     wcs = WCS(new_hdr)
@@ -3125,7 +3124,9 @@ def join_spec_channels(in_rss: List[str], out_rss: str, use_weights: bool = True
     new_hdr.update(wcs.to_header())
     new_rss = RSS(data=new_data, error=new_error, mask=new_mask, wave=new_wave, inst_fwhm=new_inst_fwhm, sky=new_sky, sky_error=new_sky_error, header=new_hdr)
     # write output RSS
-    new_rss.writeFitsData(out_rss)
+    if out_rss is not None:
+        log.info(f"writing output RSS to {os.path.basename(out_rss)}")
+        new_rss.writeFitsData(out_rss)
 
     return new_rss
 

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -749,18 +749,19 @@ def run_drp(mjd: Union[int, str, list], bias: bool = False, dark: bool = False,
     mjd = list(set(sub['mjd']))[0]
     tileid = list(set(sub['tileid']))[0]
 
-    # perform camera combination
-    # produces ancillary/lvm-object-sp[id]-[expnum] files
-    for tileid, mjd in sub.groupby(['tileid', 'mjd']).groups.keys():
-        combine_channels(tileid, mjd, spec=1)
-        combine_channels(tileid, mjd, spec=2)
-        combine_channels(tileid, mjd, spec=3)
-
     # perform spectrograph combination
-    # produces lvm-CFrame file
+    # produces ancillary/lvm-object-[channel]-[expnum] files
     exposures = set(sci['expnum'].sort_values())
     for expnum in exposures:
-        combine_spectrographs(tileid, mjd, expnum)
+        combine_spectrographs(tileid, mjd, "b", expnum)
+        combine_spectrographs(tileid, mjd, "r", expnum)
+        combine_spectrographs(tileid, mjd, "z", expnum)
+    
+    # perform camera combination
+    # produces lvm-CFrame file
+    for tileid, mjd, expnum in sub.groupby(['tileid', 'mjd', 'expnum']).groups.keys():
+        combine_channels(tileid, mjd, expnum)
+
 
     # perform sky subtraction
 

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -9,6 +9,7 @@ from typing import Union
 from functools import lru_cache
 from itertools import groupby
 import numpy as np
+from numpy.lib import recfunctions as rfn
 
 import astropy.units as u
 from astropy.io import fits
@@ -20,7 +21,7 @@ from lvmdrp.functions.imageMethod import (preproc_raw_frame, create_master_frame
                                           find_peaks_auto, trace_peaks,
                                           extract_spectra)
 from lvmdrp.functions.rssMethod import (determine_wavelength_solution, create_pixel_table,
-                                        resample_wavelength, join_spec_channels)
+                                        resample_wavelength, join_spec_channels, stack_rss)
 from lvmdrp.utils.metadata import (get_frames_metadata, get_master_metadata, extract_metadata,
                                    get_analog_groups, match_master_metadata, create_master_path)
 from lvmdrp import config, log, path, __version__ as drpver
@@ -751,9 +752,9 @@ def run_drp(mjd: Union[int, str, list], bias: bool = False, dark: bool = False,
     # perform camera combination
     # produces ancillary/lvm-object-sp[id]-[expnum] files
     for tileid, mjd in sub.groupby(['tileid', 'mjd']).groups.keys():
-        combine_cameras(tileid, mjd, spec=1)
-        combine_cameras(tileid, mjd, spec=2)
-        combine_cameras(tileid, mjd, spec=3)
+        combine_channels(tileid, mjd, spec=1)
+        combine_channels(tileid, mjd, spec=2)
+        combine_channels(tileid, mjd, spec=3)
 
     # perform spectrograph combination
     # produces lvm-CFrame file
@@ -976,12 +977,12 @@ def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
     return supersky
 
 
-def combine_cameras(tileid: int, mjd: int, expnum: int = None, spec: int = 1):
-    """ Combine the cameras together
+def combine_channels(tileid: int, mjd: int, expnum: int):
+    """ Combine the spectrograph channels together
 
-    Combines all available cameras (b, r, z) together on a given
-    spectrograph. For all exposures, combines all "hobject" ancillary
-    files into a single "bobject" ancillary file, per spectrograph.
+    For a given exposure, combines the three spectograph channels together
+    into a single output lvm-CFrame file.  The input files are the
+    ancillary spectrograph-combined lvm-object-[channel]-[expnum] files.
 
     Parameters
     ----------
@@ -989,106 +990,34 @@ def combine_cameras(tileid: int, mjd: int, expnum: int = None, spec: int = 1):
         the sky tileid
     mjd : int
         the MJD of observation
-    spec : int, optional
-        the spectrograph id, by default 1
+    expnum : int
+        the exposure number
     """
-    from itertools import groupby
-
-    # pattern = f'*hobject-*-*{spec}-*'
-    # hfiles = sorted(list(pathlib.Path(os.getenv('LVM_SPECTRO_REDUX')).rglob(pattern)),
-    #                 key=_parse_expnum_cam)
 
     # find all the h object files
-    hfiles = path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                         imagetype='object', expnum=expnum or '****', kind='h', camera=f'*{spec}')
-    hfiles = map(pathlib.Path, sorted(hfiles, key=_parse_expnum_cam))
+    files = path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
+                         imagetype='object', expnum=expnum, kind='', camera='*')
+    files = map(pathlib.Path, sorted(files, key=_parse_expnum_cam))
 
-    log.info(f'--- Combining cameras from spec {spec} ---')
-    kwargs = get_config_options('reduction_steps.combine_cameras')
+    cframe_path = path.full("lvm_frame", mjd=mjd, drpver=drpver, tileid=tileid, expnum=expnum, kind='CFrame')
+
+    log.info(f'combining channels for {expnum = }')
+    kwargs = get_config_options('reduction_steps.combine_channels')
     log.info(f'custom configuration parameters for combine cameras: {repr(kwargs)}')
 
-    m = [f'b{spec}', f'r{spec}', f'z{spec}']
-
-    # loop over all files, grouped by exposure
-    for key, exps in groupby(hfiles, lambda x: int(x.stem.split('-')[-1])):
-        log.info(f'combining cameras for exposure {key}')
-
-        # create the output b object file, 1 per spectrograph
-        bout_file = path.full('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                              imagetype='object', expnum=key, kind='', camera=f'sp{spec}')
-
-        # pad the exposure list for missing cameras
-        exps = list(exps)
-        if len(exps) == 2:
-            x = [any(e.match(f'*{n}*') for e in exps) for n in m]
-            exps.insert(x.index(False), None)
-
-        # combine the b, r, z channels together
-        join_spec_channels(in_rss=list(exps), out_rss=bout_file, use_weights=True, **kwargs)
-        log.info(f'Output combined camera file: {bout_file}')
-
-
-def combine_spectrographs(tileid: int, mjd: int, expnum: int) -> fits.HDUList:
-    """ Combine the spectrographs together for a given exposure
-
-    For a given exposure, combines the three spectographs together
-    into a single output lvm-CFrame file.  The input files are the
-    ancillary camera-combined lvm-object-sp[id]-[expnum] files.
-
-    Parameters
-    ----------
-    tileid : int
-        The tileid of the observation
-    mjd : int
-        The MJD of the observation
-    expnum : int
-        The exposure number of the frames to combines
-
-    Returns
-    -------
-    fits.HDUList
-        the output FITS file
-    """
-
-    files = sorted(path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                               kind='', camera='sp*', imagetype='object', expnum=expnum))
-
-    if not files:
-        log.error(f'No camera-combined files found for expnum: {expnum}')
-        return
-
-    if len(files) != 3:
-        log.warning(f'Warning: Not all specids found for expnum: {expnum}')
-
-    # construct output path
-    cframe = path.full('lvm_frame', mjd=mjd, tileid=tileid, drpver=drpver,
-                       kind='CFrame', expnum=expnum)
-
-    # get the first header
-    with fits.open(files[0]) as hdu:
-        hdr = hdu[0].header.copy()
+    # combine the b, r, z channels together
+    rss_comb = join_spec_channels(in_rss=files, out_rss=None, use_weights=True, **kwargs)
 
     # build the wavelength axis
+    hdr = rss_comb._header
     wcs = WCS(hdr)
     n_wave = hdr['NAXIS1']
     wl = wcs.spectral.all_pix2world(np.arange(n_wave), 0)[0].astype("float32")
     wave = fits.ImageHDU((wl * u.m).to(u.angstrom).value, name='WAVE')
 
-    # get total number of fibers from the fibermap
-    # do we use this to check the total output fiber number? should be the same?
-    total_fibers = len(fibermap.data)
-
-    # stack the data in the extensions
-    flux_data = stack_ext(files, ext=0)
-    err_data = stack_ext(files, ext='ERROR')
-    mask_data = stack_ext(files, ext='BADPIX')
-    fwhm_data = stack_ext(files, ext='INSTFWHM')
-    sky_data = stack_ext(files, ext="SKY")
-    sky_error = stack_ext(files, ext="SKY_ERROR")
-
     # update the primary header
-    hdr['SPEC'] = ', '.join([i.split('-')[2] for i in files])
-    hdr['FILENAME'] = pathlib.Path(cframe).name
+    hdr['SPEC'] = ', '.join([f"sp{specid+1}" for specid in range(3)])
+    hdr['FILENAME'] = pathlib.Path(cframe_path).name
     hdr['DRPVER'] = drpver
 
     # remove the wcs from the primary header; add it to flux header
@@ -1102,20 +1031,65 @@ def combine_spectrographs(tileid: int, mjd: int, expnum: int) -> fits.HDUList:
 
     # create the new FITS file
     prim = fits.PrimaryHDU(header=hdr)
-    flux = fits.ImageHDU(flux_data, name='FLUX', header=fits.Header(newhdr))
-    err = fits.ImageHDU(err_data, name='ERROR')
-    mask = fits.ImageHDU(mask_data, name='MASK')
-    fwhm = fits.ImageHDU(fwhm_data, name='FWHM')
-    sky = fits.ImageHDU(sky_data, name="SKY")
-    sky_error = fits.ImageHDU(sky_error, name="SKY_ERROR")
+    flux = fits.ImageHDU(rss_comb._data, name='FLUX', header=fits.Header(newhdr))
+    err = fits.ImageHDU(rss_comb._error, name='ERROR')
+    mask = fits.ImageHDU(rss_comb._mask.astype("uint8"), name='MASK')
+    fwhm = fits.ImageHDU(rss_comb._inst_fwhm, name='FWHM')
+    sky = fits.ImageHDU(rss_comb._sky, name="SKY")
+    sky_error = fits.ImageHDU(rss_comb._sky_error, name="SKY_ERROR")
 
     # build super sky
     supersky = build_supersky(tileid, mjd, expnum)
 
-    hdulist = fits.HDUList([prim, flux, err, mask, wave, fwhm, sky, sky_error, supersky, fibermap])
-
     # write out new file
-    hdulist.writeto(cframe, overwrite=True)
+    log.info(f'writing output file in {os.path.basename(cframe_path)}')
+    hdulist = fits.HDUList([prim, flux, err, mask, wave, fwhm, sky, sky_error, supersky, fibermap])
+    hdulist.writeto(cframe_path, overwrite=True)
+
+
+def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> RSS:
+    """ Combine the spectrographs together for a given exposure
+
+    For a given exposure, combines the three spectographs together into a
+    single output lvm-object-[channel]-[expnum] file. The input files are the
+    ancillary rectified frames lvm-object-hobject-[channel]*-[expnum] files.
+
+    Parameters
+    ----------
+    tileid : int
+        The tileid of the observation
+    mjd : int
+        The MJD of the observation
+    channel : str
+        The channel of the spectrograph, e.g. b, r, z
+    expnum : int
+        The exposure number of the frames to combines
+
+    Returns
+    -------
+    RSS
+        The combined RSS object
+    """
+
+    hsci_paths = sorted(path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
+                               kind='h', camera=f'{channel}*', imagetype='object', expnum=expnum))
+
+    if not hsci_paths:
+        log.error(f'No rectified frames found for {expnum = }, {channel = }')
+        return
+
+    if len(hsci_paths) != 3:
+        log.warning(f'Not all spectrographs found for {expnum = }, {channel = }')
+
+    # construct output path
+    frame_path = path.full('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
+                        kind='', camera=channel, imagetype="object", expnum=expnum)
+
+
+    # combine RSS files along fiber ID direction
+    spec_comb = stack_rss(hsci_paths, frame_path, axis=0)
+
+    return spec_comb
 
 
 def stack_ext(files: list, ext: Union[int, str] = 0) -> np.array:

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -998,7 +998,7 @@ def combine_channels(tileid: int, mjd: int, expnum: int):
     # find all the h object files
     files = path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
                          imagetype='object', expnum=expnum, kind='', camera='*')
-    files = map(pathlib.Path, sorted(files, key=_parse_expnum_cam))
+    files = sorted(files, key=_parse_expnum_cam)
 
     cframe_path = path.full("lvm_frame", mjd=mjd, drpver=drpver, tileid=tileid, expnum=expnum, kind='CFrame')
 
@@ -1007,7 +1007,7 @@ def combine_channels(tileid: int, mjd: int, expnum: int):
     log.info(f'custom configuration parameters for combine cameras: {repr(kwargs)}')
 
     # combine the b, r, z channels together
-    rss_comb = join_spec_channels(in_rss=files, out_rss=None, use_weights=True, **kwargs)
+    rss_comb = join_spec_channels(in_rsss=files, out_rss=None, use_weights=True, **kwargs)
 
     # build the wavelength axis
     hdr = rss_comb._header
@@ -1076,11 +1076,11 @@ def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> R
                                kind='h', camera=f'{channel}*', imagetype='object', expnum=expnum))
 
     if not hsci_paths:
-        log.error(f'No rectified frames found for {expnum = }, {channel = }')
+        log.error(f'no rectified frames found for {expnum = }, {channel = }')
         return
 
     if len(hsci_paths) != 3:
-        log.warning(f'Not all spectrographs found for {expnum = }, {channel = }')
+        log.warning(f'not all spectrographs found for {expnum = }, {channel = }')
 
     # construct output path
     frame_path = path.full('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -248,13 +248,13 @@ def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction
         # add sensitivity curve as FLUXCAL extension
         flux_tasks.fluxcal_Gaia(sci_camera, hsci_path, GAIA_CACHE_DIR=ORIG_MASTER_DIR)
 
-    # combine channels
-    drp.combine_cameras(sci_tileid, sci_mjd, expnum=sci_expnum, spec=1)
-    drp.combine_cameras(sci_tileid, sci_mjd, expnum=sci_expnum, spec=2)
-    drp.combine_cameras(sci_tileid, sci_mjd, expnum=sci_expnum, spec=3)
-
     # combine spectrographs
-    drp.combine_spectrographs(sci_tileid, sci_mjd, sci_expnum)
+    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="b", expnum=sci_expnum)
+    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="r", expnum=sci_expnum)
+    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="z", expnum=sci_expnum)
+
+    # combine channels
+    drp.combine_channels(tileid=sci_tileid, mjd=sci_mjd, expnum=sci_expnum)
 
     # TODO: add quick report routine
 


### PR DESCRIPTION
Refactoring camera frames combination. Main changes are:

- Refactoring `glueRSS`, now `stack_rss` to stack RSS objects along given axis
- Adding missing `_sky_error` stacking
- Swapping channel first, spec second for spec first, channel second
- Deprecating ancillary `lvm-object-sp{123}-[expnum].fits` file in favor of `lvm-object-{brz}-[expnum].fits`