### PR TITLE
Updates DRP for runs at Utah

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,13 @@ Change Log
 
 This document records the main changes to the drp code.
 
-0.1.1 (unreleased)
+0.1.2 (unreleased)
 ------------------
+
+
+0.1.1 (11-08-2023)
+------------------
+- Tag of drp after new quick_reduction DRP, before changes for Utah
 
 0.1.0 (07-13-2023)
 ------------------

--- a/bin/drp
+++ b/bin/drp
@@ -7,12 +7,12 @@ import cloup
 from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
 
 from astropy.io import fits
-from lvmdrp.functions.run_drp import run_drp, get_config_options, reduce_file
+from lvmdrp.functions.run_drp import run_drp, get_config_options, reduce_file, check_daily_mjd
 from lvmdrp.functions.imageMethod import preproc_raw_frame
 from lvmdrp.functions.skyMethod import configureSkyModel_drp
 from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
 
-from lvmdrp.functions.run_quickdrp import quick_reduction
+from lvmdrp.functions.run_quickdrp import quick_science_reduction
 
 
 @click.group('drp', short_help='CLI for the LVM data reduction')
@@ -24,42 +24,41 @@ def cli():
 @click.option('-m', '--mjd', type=int, help='an MJD to reduce')
 @click.option('-l', '--mjd-list', type=int, multiple=True, help='a list of specific MJDs to reduce')
 @click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
-@click.option('--skip-bd', is_flag=True, default=False, help='Flag to skip bias/dark reduction')
-@click.option('--arc', is_flag=True, default=False, help='Flag to only reduce arc frames')
-@click.option('--flat', is_flag=True, default=False, help='Flag to only reduce flat frames')
-@click.option('--only-bd', is_flag=True, default=False, help='Flag to only reduce bias/dark frames')
-@click.option('--only-cal', is_flag=True, default=False, help='Flag to only reduce calibration frames')
-@click.option('--only-sci', is_flag=True, default=False, help='Flag to only reduce science frames')
-@click.option('--pixmask', is_flag=True, default=False, help='Flag to create pixelmask from bias/dark/pixelflat frames')
-@click.option('-s', '--spec', type=click.Choice(['1', '2', '3']), help='The spectrograph id to reduce')
-@click.option('-c', '--camera', type=click.Choice(['b', 'r', 'z']), help='The camera to reduce')
+@click.option('--with-cals', is_flag=True, default=False, help='Flag to include indiviual calibration frames')
+@click.option('--no-sci', is_flag=True, default=False, help='Flag to exclude science frame reductions')
 @click.option('-e', '--expnum', type=int, help='an exposure number to reduce')
 @click.option('-el', '--exp-list', type=int, multiple=True, help='a list of specific exposures to reduce')
 @click.option('-er', '--exp-range', type=str, help='a range of exposure numbers to reduce')
-@click.option('-q', '--quick', is_flag=True, default=False, help='Flag for quick reductions only')
 @cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
 @cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
 @cloup.constraint(mutually_exclusive, ['expnum', 'exp_list', 'exp_range'])
-def run(mjd, mjd_list, mjd_range, skip_bd, arc, flat, only_bd, only_cal, only_sci, pixmask, camera, spec,
-        expnum, exp_list, exp_range, quick):
+def run(mjd, mjd_list, mjd_range, with_cals, no_sci, expnum, exp_list, exp_range):
     """ Run the DRP reduction for a given MJD or range of MJDs
 
     Run the DRP for an MJD or range of MJDs.  Various flags and options are available
-    for filtering on bias/darks, calibration (arc/flats) or science frames, specific
-    cameras or spectrographs, or specific exposures.
+    for filtering on calibration or science frames, or specific exposures.
 
     """
     mjd = mjd or mjd_list or mjd_range
     expnum = expnum or exp_list or exp_range
-    run_drp(mjd=mjd, flat=flat, arc=arc, skip_bd=skip_bd, only_bd=only_bd,
-            only_cal=only_cal, only_sci=only_sci, pixmask=pixmask, camera=camera, spec=spec,
-            expnum=expnum, quick=quick)
+    run_drp(mjd=mjd, expnum=expnum, no_sci=no_sci, with_cals=with_cals)
 
 
 # register full DRP command
 cli.add_command(run)
-# register quick DRP command
-cli.add_command(quick_reduction)
+
+
+@cli.command('check', short_help='Check for daily run of the DRP at Utah')
+@click.option('-t', '--test', is_flag=True, default=False, help='Test the check without running the DRP')
+@click.option('--with-cals', is_flag=True, default=False, help='Flag to include indiviual calibration frames')
+def check_daily(test, with_cals):
+    """ Checks the current MJD and starts the DRP
+
+    Checks the current daily MJD againt the Utah data transfer, and if
+    complete, starts the DRP run at Utah.
+
+    """
+    check_daily_mjd(test=test, with_cals=with_cals)
 
 
 @cli.command('reduce_file', short_help='Reduce a single file')
@@ -127,6 +126,23 @@ def regen(mjd: int, masters: bool):
 metacli.add_command(regen)
 
 cli.add_command(metacli)
+
+
+@click.command(short_help='Run the Quick DRP')
+@click.option('-e', '--expnum', type=int, help='an exposure number to reduce')
+@click.option('-f', '--use-fiducial-master', is_flag=True, default=False, help='use fiducial master calibration frames')
+@click.option('-s', '--skip-sky-subtraction', is_flag=True, help='skip sky subtraction')
+@click.option('--sky-weights', type=(float, float), default=None, help='weights (east, west) for the master sky combination')
+@click.option('-n', '--ncpus', type=int, default=None, help='number of CPUs to use during extraction')
+@click.option("-a", "--aperture-extraction", is_flag=True, default=False, help="run quick reduction with aperture extraction")
+def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction: bool,
+                    sky_weights: tuple, ncpus: int, aperture_extraction: bool) -> None:
+    quick_science_reduction(expnum, use_fiducial_master, skip_sky_subtraction,
+                            sky_weights, ncpus, aperture_extraction)
+
+
+# register quick DRP command
+cli.add_command(quick_reduction)
 
 
 if __name__ == "__main__":

--- a/python/lvmdrp/__init__.py
+++ b/python/lvmdrp/__init__.py
@@ -34,4 +34,4 @@ def setup_paths(release: str = 'sdsswork', replant: bool = False):
 path = setup_paths()
 
 
-__version__ = get_package_version(path=__file__, package_name=NAME) or os.getenv("LVMDRP_VERSION", "dev")
+__version__ = os.getenv("LVMDRP_VERSION") or get_package_version(path=__file__, package_name=NAME)

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -4,15 +4,18 @@
 import os
 import pathlib
 import yaml
+import shutil
+import traceback
 import pandas as pd
 from typing import Union
 from functools import lru_cache
 from itertools import groupby
-import numpy as np
 
+import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
+from astropy.time import Time
 from astropy.wcs import WCS
 from lvmdrp.core.rss import RSS
 from lvmdrp.functions.imageMethod import (preproc_raw_frame, create_master_frame,
@@ -23,6 +26,8 @@ from lvmdrp.functions.rssMethod import (determine_wavelength_solution, create_pi
                                         resample_wavelength, join_spec_channels, stack_rss)
 from lvmdrp.utils.metadata import (get_frames_metadata, get_master_metadata, extract_metadata,
                                    get_analog_groups, match_master_metadata, create_master_path)
+from lvmdrp.functions.run_quickdrp import quick_science_reduction
+
 from lvmdrp import config, log, path, __version__ as drpver
 
 
@@ -613,7 +618,7 @@ def reduce_masters(mjd: int):
         reduce_frame(path, master=True, **row)
 
 
-def run_drp(mjd: Union[int, str, list], bias: bool = False, dark: bool = False,
+def run_drp_deprecated(mjd: Union[int, str, list], bias: bool = False, dark: bool = False,
             pixelflat: bool = False, skip_bd: bool = False, arc: bool = False, flat: bool = False,
             only_bd: bool = False, only_cal: bool = False, only_sci: bool = False, pixmask: bool = False,
             spec: int = None, camera: str = None, expnum: Union[int, str, list] = None,
@@ -755,7 +760,7 @@ def run_drp(mjd: Union[int, str, list], bias: bool = False, dark: bool = False,
         combine_spectrographs(tileid, mjd, "b", expnum)
         combine_spectrographs(tileid, mjd, "r", expnum)
         combine_spectrographs(tileid, mjd, "z", expnum)
-    
+
     # perform camera combination
     # produces lvm-CFrame file
     for tileid, mjd, expnum in sub.groupby(['tileid', 'mjd', 'expnum']).groups.keys():
@@ -932,7 +937,7 @@ def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
     # select files for sky fibers
     fsci_paths = sorted(path.expand("lvm_anc", mjd=mjd, tileid=tileid, drpver=drpver,
                                 kind="f", camera="*", imagetype="object", expnum=expnum))
-    
+
     fsci_paths_cam = groupby(fsci_paths, lambda x: x.split("-")[-2])
     sky_wave = []
     sky = []
@@ -945,11 +950,11 @@ def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
         paths = sorted(list(paths))
 
         for sci_path in paths:
-            
+
             # load flafielded camera frame
             fsci = RSS()
             fsci.loadFitsData(sci_path)
-            
+
             # convert to density units if necessary
             if fsci._header["BUNIT"] == "electron":
                 dlambda = np.diff(fsci._wave, axis=1, append=2*(fsci._wave[:, -1] - fsci._wave[:, -2])[:, None])
@@ -1092,13 +1097,10 @@ def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> R
 
     # construct output path
     frame_path = path.full('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                        kind='', camera=channel, imagetype="object", expnum=expnum)
-
+                           kind='', camera=channel, imagetype="object", expnum=expnum)
 
     # combine RSS files along fiber ID direction
-    spec_comb = stack_rss(hsci_paths, frame_path, axis=0)
-
-    return spec_comb
+    return stack_rss(hsci_paths, frame_path, axis=0)
 
 
 def stack_ext(files: list, ext: Union[int, str] = 0) -> np.array:
@@ -1234,3 +1236,264 @@ def add_extension(hdu: Union[fits.ImageHDU, fits.BinTableHDU], filename: str):
         if hdu.name not in hdulist:
             hdulist.append(hdu)
             hdulist.flush()
+
+
+def _yield_dir(root: pathlib.Path, mjd: int) -> pathlib.Path:
+    """ Iteratively yield a pathlib directory
+
+    Parameters
+    ----------
+    root : pathlib.Path
+        the top-level path
+    mjd : int
+        the MJD to look for
+
+    Yields
+    ------
+    Iterator[pathlib.Path]
+        the pathlib.Path
+    """
+    for item in root.iterdir():
+        if item.stem == str(mjd):
+            yield item
+        if item.is_dir():
+            yield from _yield_dir(item, mjd)
+
+
+def should_run(mjd: int) -> bool:
+    """ Check if the DRP should be run
+
+    Checks to see if the DRP should be run for the
+    given MJD.  Checks if the data transfer has completed
+    and that no pipeline run has started yet.
+
+    Parameters
+    ----------
+    mjd : int
+        the MJD
+
+    Returns
+    -------
+    bool
+        Flag if the pipeline should be run
+    """
+
+    # not transferred yet
+    done = pathlib.Path(os.getenv("LCO_STAGING_DATA")) / f'log/lvm/{mjd}/transfer-{mjd}.done'
+    if not done.exists() or not done.is_file():
+        # data not transferred yet, skip DRP running
+        log.warning(f'Data transfer not yet complete for MJD {mjd}.')
+        return False
+
+    # check for MJD directory and any files in it
+    # if no directory or no raw_metadata file in it, we run the DRP
+    root = pathlib.Path(os.getenv("LVM_SPECTRO_REDUX")) / f'{drpver}'
+    mjddir = list(_yield_dir(root, mjd))
+    return not any(mjddir[0].glob('raw_meta*')) if mjddir else True
+
+
+def check_daily_mjd(test: bool = False, with_cals: bool = False):
+    """ Check for daily MJD run
+
+    Get the MJD for the current datetime and check if
+    we should run the DRP or not.  If so, start the DRP
+    for the given MJD.
+
+    Parameters
+    ----------
+    test : bool, optional
+        Flag to test the check without running the DRP, by default False
+    with_cals: bool, optional
+        Flag to turn on reduction of the individual calibration files
+    """
+    # get current MJD
+    t = Time.now()
+    mjd = int(t.mjd)
+    log.info(f'It is {t.to_string()}.  The MJD is {int(t.mjd)}.')
+
+    # check if we should run the DRP
+    if should_run(mjd):
+        log.info(f"Running DRP for mjd {mjd}")
+        if not test:
+            run_drp(mjd, with_cals=with_cals)
+
+
+def create_status_file(tileid: int, mjd: int, status: str = 'started'):
+    """ Create a DRP status file
+
+    Create a DRP status file for the given tile_id, MJD.
+
+    Parameters
+    ----------
+    tileid : int
+        the tile iD
+    mjd : int
+        the MJD
+    status : str, optional
+        the DRP status, by default 'started'
+    """
+    root = pathlib.Path(os.getenv("LVM_SPECTRO_REDUX")) / f'{drpver}' / 'logs'
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f'lvm-drp-{tileid}-{mjd}.{status}'
+    path.touch()
+
+
+def remove_status_file(tileid: int, mjd: int, remove_all: bool = False):
+    """ Remove a DRP status file
+
+    Remove a DRP status file for the given tile_id, MJD, or
+    optionally remove all status files.
+
+    Parameters
+    ----------
+    tileid : int
+        the tile iD
+    mjd : int
+        the MJD
+    remove_all : bool, optional
+        Flag to remove all status files, by default False
+    """
+    root = pathlib.Path(os.getenv("LVM_SPECTRO_REDUX")) / f'{drpver}' / 'logs'
+
+    if remove_all:
+        shutil.rmtree(root)
+        return
+
+    files = root.rglob(f'lvm-drp-{tileid}-{mjd}.*')
+    for file in files:
+        file.unlink()
+
+
+def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
+            with_cals: bool = False, no_sci: bool = False):
+    """ Run the quick DRP
+
+    Run the quick DRP for an MJD, or a range of MJDs. Reduces
+    science frames with the function ``run_quickdrp.quick_science_reduction``.
+    Optionally can set flags to attempt reduction of the individual calibration
+    frames in the MJD up through detrending, or to turn off science frame
+    reduction.
+
+    Parameters
+    ----------
+    mjd : Union[int, str, list]
+        the MJD to reduce
+    expnum : Union[int, str, list], optional
+        the exposure numbers to reduce, by default None
+    with_cals : bool, optional
+        Flag to reduce individual calibration files, by default False
+    no_sci : bool, optional
+        Flag to turn off science frame reduction, by default False
+    """
+    # # write the drp parameter configuration
+    # write_config_file()
+
+    # parse the input MJD and loop over all reductions
+    mjds = parse_mjds(mjd)
+    if isinstance(mjds, list):
+        for mjd in mjds:
+            run_drp(mjd=mjd, expnum=expnum, with_cals=with_cals, no_sci=no_sci)
+        return
+
+    log.info(f'Processing MJD {mjd}')
+
+    # check the MJD data directory path
+    mjd_path = pathlib.Path(os.getenv('LVM_DATA_S')) / str(mjd)
+    log.info(f'MJD processing path: {mjd_path}')
+    if not mjd_path.is_dir():
+        log.warning(f'{mjd = } is not valid raw data directory.')
+        return
+
+    # generate the MJD metadata
+    frames = get_frames_metadata(mjd=mjd)
+    sub = frames.copy()
+
+    # remove bad or test quality frames
+    sub = sub[~(sub['quality'] != 'excellent')]
+
+    # filter on exposure number
+    if expnum:
+        log.info(f'Filtering on exposure numbers {expnum}.')
+        sub = filter_expnum(sub, expnum)
+
+    # group the frames
+    sub = sub.sort_values(['expnum', 'camera'])
+
+    # split into cals, and science
+    cals = sub[~(sub['imagetyp'] == 'object')]
+    sci = sub[sub['imagetyp'] == 'object']
+
+    # start logging for this mjd
+    tileid = sci["tileid"].unique()[0]
+    start_logging(mjd, tileid)
+
+    # create start status
+    create_status_file(tileid, mjd, status='started')
+
+    # attempt to reduce individual calibration files
+    if not cals.empty and with_cals:
+        for row in cals.to_dict("records"):
+            try:
+                reduce_calib_frame(row)
+            except Exception as e:
+                log.error(f'Failed to reduce calib frame mjd {mjd} exposure {row["expnum"]}: {e}')
+                trace = traceback.format_exc()
+                log.error(trace)
+
+    # reduce the science data
+    if not sci.empty and not no_sci:
+        for expnum in sci['expnum'].unique():
+            try:
+                quick_science_reduction(expnum, use_fiducial_master=True)
+            except Exception as e:
+                log.error(f'Failed to reduce science frame mjd {mjd} exposure {expnum}: {e}')
+                create_status_file(tileid, mjd, status='error')
+                trace = traceback.format_exc()
+                log.error(trace)
+                return
+
+    # create done status
+    create_status_file(tileid, mjd, status='done')
+
+
+def reduce_calib_frame(row: dict):
+    """ Reduce an individual calibration frame
+
+    Tries to reduce an individual calibration exposure through
+    the preprocessing and detrending stages.  Considered files
+    are bias, darks, arcs, and flats.
+
+    Parameters
+    ----------
+    row : dict
+        info from the raw_metadata file
+    """
+    # get raw frame filepath
+    filename = path.full('lvm_raw', **row, camspec=row['camera'])
+
+    log.info(f'--- Starting calibration reduction of raw frame: {filename}')
+
+    # set flavor
+    flavor = row.get('imagetyp')
+    flavor = 'fiberflat' if flavor == 'flat' else flavor
+
+    # get master calibration paths
+    mpixmask = path.full('lvm_calib', mjd=row['mjd'], camera=row['camera'], kind='pixmask')
+    mbias = path.full('lvm_calib', mjd=row['mjd'], camera=row['camera'], kind='bias')
+    mdark = path.full('lvm_calib', mjd=row['mjd'], camera=row['camera'], kind='dark')
+    mpixflat = path.full('lvm_calib', mjd=row['mjd'], camera=row['camera'], kind='pixflat')
+
+    # preprocess the frames
+    log.info('--- Preprocessing raw frame ---')
+    out_pre = path.full('lvm_anc', kind='p', drpver=drpver, imagetype=flavor, **row)
+    preproc_raw_frame(in_image=filename, in_mask=mpixmask, out_image=out_pre)
+
+    # detrend the frames
+    log.info('--- Running detrend frame ---')
+
+    in_cal = path.full('lvm_anc', kind='p', drpver=drpver, imagetype=flavor, **row)
+    out_cal = path.full('lvm_anc', kind='d', drpver=drpver, imagetype=flavor, **row)
+
+    detrend_frame(in_image=in_cal, out_image=out_cal,
+                  in_bias=mbias, in_dark=mdark, in_pixelflat=mpixflat,
+                  in_slitmap=Table(fibermap.data), reject_cr=False)

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -1289,7 +1289,10 @@ def should_run(mjd: int) -> bool:
     # if no directory or no raw_metadata file in it, we run the DRP
     root = pathlib.Path(os.getenv("LVM_SPECTRO_REDUX")) / f'{drpver}'
     mjddir = list(_yield_dir(root, mjd))
-    return not any(mjddir[0].glob('raw_meta*')) if mjddir else True
+    no_files = not any(mjddir[0].glob('raw_meta*')) if mjddir else True
+    if not no_files:
+        log.info(f"DRP for mjd {mjd} already running.")
+    return no_files
 
 
 def check_daily_mjd(test: bool = False, with_cals: bool = False):

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -1367,6 +1367,28 @@ def remove_status_file(tileid: int, mjd: int, remove_all: bool = False):
         file.unlink()
 
 
+def status_file_exists(tileid: int, mjd: int, status: str = 'started') -> bool:
+    """ Check if a status file exists
+
+    Parameters
+    ----------
+    tileid : int
+        the tile iD
+    mjd : int
+        the MJD
+    status : str, optional
+        the DRP status, by default 'started'
+
+    Returns
+    -------
+    bool
+        Flag if the file exists
+    """
+    root = pathlib.Path(os.getenv("LVM_SPECTRO_REDUX")) / f'{drpver}' / 'logs'
+    path = root / f'lvm-drp-{tileid}-{mjd}.{status}'
+    return path.exists()
+
+
 def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
             with_cals: bool = False, no_sci: bool = False):
     """ Run the quick DRP
@@ -1468,7 +1490,8 @@ def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
                     break
 
         # create done status
-        create_status_file(tileid, mjd, status='done')
+        if status_file_exists(tileid, mjd, 'started'):
+            create_status_file(tileid, mjd, status='done')
 
 
 def reduce_calib_frame(row: dict):

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -117,14 +117,11 @@ def get_master_mjd(sci_mjd: int) -> int:
     return int(target_master[-1])
 
 
-@click.command(short_help='Run the Quick DRP')
-@click.option('-e', '--expnum', type=int, help='an exposure number to reduce')
-@click.option('-f', '--use-fiducial-master', is_flag=True, default=False, help='use fiducial master calibration frames')
-@click.option('-s', '--skip-sky-subtraction', is_flag=True, help='skip sky subtraction')
-@click.option('--sky-weights', type=(float, float), default=None, help='weights (east, west) for the master sky combination')
-@click.option('-n', '--ncpus', type=int, default=None, help='number of CPUs to use during extraction')
-@click.option("-a", "--aperture-extraction", is_flag=True, default=False, help="run quick reduction with aperture extraction")
-def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction: bool, sky_weights: Tuple[float, float], ncpus: int, aperture_extraction: bool) -> None:
+def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
+                            skip_sky_subtraction: bool = False,
+                            sky_weights: Tuple[float, float] = None,
+                            ncpus: int = None,
+                            aperture_extraction: bool = False) -> None:
     """ Run the Quick DRP for a given exposure number.
     """
     # validate parameters
@@ -221,6 +218,8 @@ def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction
             mwave_path = path.full("lvm_master", drpver=drpver, kind=f"mwave_{lamps}", **masters["wave"].to_dict())
             mlsf_path = path.full("lvm_master", drpver=drpver, kind=f"mlsf_{lamps}", **masters["lsf"].to_dict())
             mflat_path = path.full("lvm_master", drpver=drpver, kind="mfiberflat", **masters["fiberflat"].to_dict())
+
+        log.info(f'--- Starting science reduction of raw frame: {rsci_path}')
 
         # preprocess frame
         image_tasks.preproc_raw_frame(in_image=rsci_path, out_image=psci_path, in_mask=mpixmask_path)

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -9,7 +9,6 @@
 
 import os
 import click
-import cloup
 import numpy as np
 from typing import Tuple
 
@@ -28,54 +27,54 @@ from lvmdrp.core.constants import SPEC_CHANNELS
 ORIG_MASTER_DIR = os.getenv("LVM_MASTER_DIR")
 
 
-def illumination_correction(in_fiberflat=None):
+def illumination_correction(in_fiberflat: bool = None) -> dict:
     if in_fiberflat is None:
         # NOTE: this was done using exposure 3900
         factors = {('SkyW', 'b1'): 0.8854398,
-                    ('SkyE', 'b1'): 1.0811657,
-                    ('Sci', 'b1'): 1.0333946,
-                    ('Spec', 'b1'): 1.3,
-                    ('SkyW', 'r1'): 0.9435192,
-                    ('SkyE', 'r1'): 1.0190876,
-                    ('Sci', 'r1'): 1.0373933,
-                    ('Spec', 'r1'): 1.3,
-                    ('SkyW', 'z1'): 0.9378496,
-                    ('SkyE', 'z1'): 1.0072966,
-                    ('Sci', 'z1'): 1.0548539,
-                    ('Spec', 'z1'): 1.3,
-                    ('SkyW', 'b2'): 0.9148656,
-                    ('SkyE', 'b2'): 1.0618604,
-                    ('Sci', 'b2'): 1.023274,
-                    ('Spec', 'b2'): 1.3,
-                    ('SkyW', 'r2'): 0.9465178,
-                    ('SkyE', 'r2'): 1.0136424,
-                    ('Sci', 'r2'): 1.0398397,
-                    ('Spec', 'r2'): 1.3,
-                    ('SkyW', 'z2'): 0.93933785,
-                    ('SkyE', 'z2'): 1.0083715,
-                    ('Sci', 'z2'): 1.0522904,
-                    ('Spec', 'z2'): 1.3,
-                    ('SkyW', 'b3'): 0.88334155,
-                    ('SkyE', 'b3'): 1.0627162,
-                    ('Sci', 'b3'): 1.0539422,
-                    ('Spec', 'b3'): 1.3,
-                    ('SkyW', 'r3'): 0.9305622,
-                    ('SkyE', 'r3'): 1.013976,
-                    ('Sci', 'r3'): 1.0554619,
-                    ('Spec', 'r3'): 1.3,
-                    ('SkyW', 'z3'): 0.9152639,
-                    ('SkyE', 'z3'): 1.0191175,
-                    ('Sci', 'z3'): 1.0656188,
-                    ('Spec', 'z3'): 1.3}
+                   ('SkyE', 'b1'): 1.0811657,
+                   ('Sci', 'b1'): 1.0333946,
+                   ('Spec', 'b1'): 1.3,
+                   ('SkyW', 'r1'): 0.9435192,
+                   ('SkyE', 'r1'): 1.0190876,
+                   ('Sci', 'r1'): 1.0373933,
+                   ('Spec', 'r1'): 1.3,
+                   ('SkyW', 'z1'): 0.9378496,
+                   ('SkyE', 'z1'): 1.0072966,
+                   ('Sci', 'z1'): 1.0548539,
+                   ('Spec', 'z1'): 1.3,
+                   ('SkyW', 'b2'): 0.9148656,
+                   ('SkyE', 'b2'): 1.0618604,
+                   ('Sci', 'b2'): 1.023274,
+                   ('Spec', 'b2'): 1.3,
+                   ('SkyW', 'r2'): 0.9465178,
+                   ('SkyE', 'r2'): 1.0136424,
+                   ('Sci', 'r2'): 1.0398397,
+                   ('Spec', 'r2'): 1.3,
+                   ('SkyW', 'z2'): 0.93933785,
+                   ('SkyE', 'z2'): 1.0083715,
+                   ('Sci', 'z2'): 1.0522904,
+                   ('Spec', 'z2'): 1.3,
+                   ('SkyW', 'b3'): 0.88334155,
+                   ('SkyE', 'b3'): 1.0627162,
+                   ('Sci', 'b3'): 1.0539422,
+                   ('Spec', 'b3'): 1.3,
+                   ('SkyW', 'r3'): 0.9305622,
+                   ('SkyE', 'r3'): 1.013976,
+                   ('Sci', 'r3'): 1.0554619,
+                   ('Spec', 'r3'): 1.3,
+                   ('SkyW', 'z3'): 0.9152639,
+                   ('SkyE', 'z3'): 1.0191175,
+                   ('Sci', 'z3'): 1.0656188,
+                   ('Spec', 'z3'): 1.3}
 
         return factors
-    
+
     fibers = [2, 106, 37]
     fibermap = Table(drp.fibermap.data)
     select = np.isin(fibermap["fiberid"]-1, fibers)
-    skw1_fibers = fibermap[~select][fibermap[~select]["ifulabel"] == "SkyW1"]["fiberid"]-1
-    ske1_fibers = fibermap[~select][fibermap[~select]["ifulabel"] == "SkyE1"]["fiberid"]-1
-    sci1_fibers = fibermap[~select][fibermap[~select]["ifulabel"] == "Sci1"]["fiberid"]-1
+    skw1_fibers = fibermap[~select][fibermap[~select]["ifulabel"] == "SkyW1"]["fiberid"] - 1
+    ske1_fibers = fibermap[~select][fibermap[~select]["ifulabel"] == "SkyE1"]["fiberid"] - 1
+    sci1_fibers = fibermap[~select][fibermap[~select]["ifulabel"] == "Sci1"]["fiberid"] - 1
 
     factors = {}
     for spec in "123":
@@ -83,7 +82,7 @@ def illumination_correction(in_fiberflat=None):
             cam = cam + spec
             fflat = rss_tasks.RSS()
             fflat.loadFitsData(f"/home/mejia/Research/lvm/lvmdata/calib/60177/lvm-mfiberflat-{cam}.fits")
-            fflat._data[(fflat._mask)|(fflat._data <= 0)] = np.nan
+            fflat._data[(fflat._mask) | (fflat._data <= 0)] = np.nan
             sci_factor = np.nanmedian(fflat._data[sci1_fibers][:, 1000:3000])
             skw_factor = np.nanmedian(fflat._data[skw1_fibers][:, 1000:3000])
             ske_factor = np.nanmedian(fflat._data[ske1_fibers][:, 1000:3000])
@@ -91,17 +90,34 @@ def illumination_correction(in_fiberflat=None):
             factors[("SkyW", cam)] = skw_factor/norm
             factors[("SkyE", cam)] = ske_factor/norm
             factors[("Sci", cam)] = sci_factor/norm
-        
+
         return factors
 
-def get_master_mjd(sci_mjd):
 
-    masters_dir = sorted([f for f in os.listdir(ORIG_MASTER_DIR) if os.path.isdir(os.path.join(ORIG_MASTER_DIR, f))])
+def get_master_mjd(sci_mjd: int) -> int:
+    """ Get the correct master calibration MJD for a science frame
+
+    Find the most relevant master calibration MJD given an
+    input science frame MJD.
+
+    Parameters
+    ----------
+    sci_mjd : int
+        the MJD of the science exposure
+
+    Returns
+    -------
+    int
+        the master calibration MJD
+    """
+    masters_dir = sorted([f for f in os.listdir(ORIG_MASTER_DIR)
+                          if os.path.isdir(os.path.join(ORIG_MASTER_DIR, f))])
     masters_dir = [f for f in masters_dir if f.isdigit()]
     target_master = list(filter(lambda f: sci_mjd >= int(f), masters_dir))
     return int(target_master[-1])
 
-@cloup.command(short_help='Run the Quick DRP', show_constraints=True)
+
+@click.command(short_help='Run the Quick DRP')
 @click.option('-e', '--expnum', type=int, help='an exposure number to reduce')
 @click.option('-f', '--use-fiducial-master', is_flag=True, default=False, help='use fiducial master calibration frames')
 @click.option('-s', '--skip-sky-subtraction', is_flag=True, help='skip sky subtraction')
@@ -122,6 +138,7 @@ def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction
         elif sum(sky_weights) == 0.0:
             log.error("sum of sky weights must be non-zero")
             return
+
     # define extraction method
     extraction_parallel = "auto" if ncpus is None else ncpus
     extraction_method = "aperture" if aperture_extraction else "optimal"
@@ -172,7 +189,7 @@ def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction
         os.makedirs(os.path.dirname(hsci_path), exist_ok=True)
         # define current arc lamps to use for wavelength calibration
         lamps = arc_lamps[sci_camera[0]]
-        
+
         # define calibration frames paths
         if use_fiducial_master:
             masters_path = os.getenv("LVM_MASTER_DIR")
@@ -204,15 +221,15 @@ def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction
             mwave_path = path.full("lvm_master", drpver=drpver, kind=f"mwave_{lamps}", **masters["wave"].to_dict())
             mlsf_path = path.full("lvm_master", drpver=drpver, kind=f"mlsf_{lamps}", **masters["lsf"].to_dict())
             mflat_path = path.full("lvm_master", drpver=drpver, kind="mfiberflat", **masters["fiberflat"].to_dict())
-        
+
         # preprocess frame
         image_tasks.preproc_raw_frame(in_image=rsci_path, out_image=psci_path, in_mask=mpixmask_path)
-        
+
         # detrend frame
         image_tasks.detrend_frame(in_image=psci_path, out_image=dsci_path,
                                   in_bias=mbias_path, in_dark=mdark_path, in_pixelflat=mpixflat_path,
                                   in_slitmap=Table(drp.fibermap.data), reject_cr=False)
-        
+
         # # extract 1d spectra
         image_tasks.extract_spectra(in_image=dsci_path, out_rss=xsci_path, in_trace=mtrace_path, in_fwhm=mwidth_path, method=extraction_method, parallel=extraction_parallel)
 
@@ -270,4 +287,4 @@ def quick_reduction(expnum: int, use_fiducial_master: bool, skip_sky_subtraction
     # TODO: combine exposures
     # TODO: by default remove the extra files for the given expnum
 
-    # TODO: flux calibration 
+    # TODO: flux calibration

--- a/python/lvmdrp/utils/metadata.py
+++ b/python/lvmdrp/utils/metadata.py
@@ -576,10 +576,14 @@ def extract_metadata(frames_paths: list, kind: str = "raw") -> pd.DataFrame:
         # set on-lamp conditions
         onlamp = ["ON", True, 'T', 1]
 
+        # get the tile id; set null tile ids -999 to 1111
+        tileid = header.get("TILE_ID", header.get("TILEID", 1111))
+        tileid = 1111 if tileid == -999 else tileid
+
         if kind == "raw":
             new_metadata[i] = [
                 "n" if header.get("OBSERVAT") != "LCO" else "s",
-                header.get("TILEID", 1111),
+                tileid,
                 sjd,
                 header.get("MJD"),
                 header.get("IMAGETYP"),
@@ -603,7 +607,7 @@ def extract_metadata(frames_paths: list, kind: str = "raw") -> pd.DataFrame:
             ]
         elif kind == "master":
             new_metadata[i] = [
-                header.get("TILEID", 1111),
+                tileid,
                 sjd,
                 header.get("MJD"),
                 header.get("IMAGETYP"),

--- a/python/lvmdrp/utils/metadata.py
+++ b/python/lvmdrp/utils/metadata.py
@@ -577,8 +577,8 @@ def extract_metadata(frames_paths: list, kind: str = "raw") -> pd.DataFrame:
         onlamp = ["ON", True, 'T', 1]
 
         # get the tile id; set null tile ids -999 to 1111
-        tileid = header.get("TILE_ID", header.get("TILEID", 1111))
-        tileid = 1111 if tileid == -999 else tileid
+        tileid = header.get("TILE_ID") or header.get("TILEID", 1111)
+        tileid = 1111 if tileid in (-999, None) else tileid
 
         if kind == "raw":
             new_metadata[i] = [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 
 NAME = "lvmdrp"
-VERSION = "0.1.1dev"
+VERSION = "0.1.2dev"
 
 
 def run():

--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,6 @@ def run():
         ],
     )
 
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
This PR updates the DRP so it can more easily run at Utah.   It reorganizes the `quick_reduction` function so it can be called directly, as `quick_science_reduction`.  The original CLI `quick-reduction` is retained so users can continue to use it.  It deprecates the old `run_drp` code and replaces it with a new `run_drp` that uses the `quick_science_reduction` function.  It 
also adds new functions for performing MJD checks against the daily data transfer, and writing status run files.   Exposures without a `tile_id` get assigned a fake id of 1111, and output reductions are placed there. 

It also includes the option of reducing the individual calibration files up through the `detrending` stage.   This is currently turned off by default.  

Manual test runs are at https://data.sdss5.org/sas/sdsswork/lvm/spectro/redux/master/ .  I'm testing out a cron job at the moment to run a daily check.  It currently takes ~10 minutes to reduce a single exposure, using the default settings of `quick_science_reduction`.  MJD 60256 had ~28 science exposures and took ~5 hours in total.  This is simply iterating over each exposure in a single process.  If we want to parallelize this, additional work needs to done to use the Utah CHPC cluster with the `slurm` package. 

Leaving this as draft for now.  