### PR TITLE
Quick (science) reduction for calibration frames

### DIFF
--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -992,7 +992,7 @@ def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
     return supersky
 
 
-def combine_channels(tileid: int, mjd: int, expnum: int):
+def combine_channels(tileid: int, mjd: int, expnum: int, imagetype: str):
     """ Combine the spectrograph channels together
 
     For a given exposure, combines the three spectograph channels together
@@ -1011,9 +1011,9 @@ def combine_channels(tileid: int, mjd: int, expnum: int):
 
     # find all the h object files
     files = path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                         imagetype='object', expnum=expnum, kind='', camera='*')
+                         imagetype=imagetype, expnum=expnum, kind='', camera='*')
     # filter out old lvm-object-sp?-*.fits files
-    files = sorted([f for f in files if not os.path.basename(f).startswith("lvm-object-sp")], key=_parse_expnum_cam)
+    files = sorted([f for f in files if not os.path.basename(f).startswith(f"lvm-{imagetype}-sp")], key=_parse_expnum_cam)
 
     cframe_path = path.full("lvm_frame", mjd=mjd, drpver=drpver, tileid=tileid, expnum=expnum, kind='CFrame')
 

--- a/python/lvmdrp/functions/run_drp.py
+++ b/python/lvmdrp/functions/run_drp.py
@@ -919,7 +919,7 @@ def _parse_expnum_cam(name: str) -> tuple:
     return int(ss[-1]), ss[-2]
 
 
-def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
+def build_supersky(tileid: int, mjd: int, expnum: int, imagetype: str) -> fits.BinTableHDU:
     """return super sky FITS table for a given exposure
 
     Parameters
@@ -930,6 +930,8 @@ def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
         the MJD of observation
     expnum : int
         the exposure number
+    imagetype : str
+        the image type
 
     Returns
     -------
@@ -938,7 +940,7 @@ def build_supersky(tileid: int, mjd: int, expnum: int) -> fits.BinTableHDU:
     """
     # select files for sky fibers
     fsci_paths = sorted(path.expand("lvm_anc", mjd=mjd, tileid=tileid, drpver=drpver,
-                                kind="f", camera="*", imagetype="object", expnum=expnum))
+                                kind="f", camera="*", imagetype=imagetype, expnum=expnum))
 
     fsci_paths_cam = groupby(fsci_paths, lambda x: x.split("-")[-2])
     sky_wave = []
@@ -1007,6 +1009,8 @@ def combine_channels(tileid: int, mjd: int, expnum: int, imagetype: str):
         the MJD of observation
     expnum : int
         the exposure number
+    imagetype : str
+        the image type
     """
 
     # find all the h object files
@@ -1055,7 +1059,7 @@ def combine_channels(tileid: int, mjd: int, expnum: int, imagetype: str):
     sky_error = fits.ImageHDU(rss_comb._sky_error, name="SKY_ERROR")
 
     # build super sky
-    supersky = build_supersky(tileid, mjd, expnum)
+    supersky = build_supersky(tileid, mjd, expnum, imagetype)
 
     # write out new file
     log.info(f'writing output file in {os.path.basename(cframe_path)}')
@@ -1063,7 +1067,7 @@ def combine_channels(tileid: int, mjd: int, expnum: int, imagetype: str):
     hdulist.writeto(cframe_path, overwrite=True)
 
 
-def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> RSS:
+def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int, imagetype: str) -> RSS:
     """ Combine the spectrographs together for a given exposure
 
     For a given exposure, combines the three spectographs together into a
@@ -1080,6 +1084,8 @@ def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> R
         The channel of the spectrograph, e.g. b, r, z
     expnum : int
         The exposure number of the frames to combines
+    imagetype : str
+        The imagetype of the frames to combine
 
     Returns
     -------
@@ -1088,7 +1094,7 @@ def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> R
     """
 
     hsci_paths = sorted(path.expand('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                               kind='h', camera=f'{channel}*', imagetype='object', expnum=expnum))
+                               kind='h', camera=f'{channel}*', imagetype=imagetype, expnum=expnum))
 
     if not hsci_paths:
         log.error(f'no rectified frames found for {expnum = }, {channel = }')
@@ -1099,7 +1105,7 @@ def combine_spectrographs(tileid: int, mjd: int, channel: str, expnum: int) -> R
 
     # construct output path
     frame_path = path.full('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,
-                           kind='', camera=channel, imagetype="object", expnum=expnum)
+                           kind='', camera=channel, imagetype=imagetype, expnum=expnum)
 
     # combine RSS files along fiber ID direction
     return stack_rss(hsci_paths, frame_path, axis=0)

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -141,13 +141,14 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
     extraction_method = "aperture" if aperture_extraction else "optimal"
 
     # get target frames metadata
-    sci_metadata = md.get_metadata(tileid="*", mjd="*", expnum=expnum, imagetyp="object")
+    sci_metadata = md.get_metadata(tileid="*", mjd="*", expnum=expnum)
     sci_metadata.sort_values("expnum", ascending=False, inplace=True)
 
     # define general metadata
     sci_tileid = sci_metadata["tileid"].unique()[0]
     sci_mjd = sci_metadata["mjd"].unique()[0]
     sci_expnum = sci_metadata["expnum"].unique()[0]
+    sci_imagetyp = sci_metadata["imagetyp"].unique()[0]
     log.info(f"running Quick DRP for tile {sci_tileid} at MJD {sci_mjd} with exposure number {sci_expnum}")
 
     master_mjd = get_master_mjd(sci_mjd)
@@ -267,7 +268,7 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
         # use sky subtracted resampled frames for flux calibration in each camera
         flux_tasks.fluxcal_Gaia(sci_camera, hsci_path, GAIA_CACHE_DIR=ORIG_MASTER_DIR+'/gaia_cache')
 
-    # # combine spectrographs
+    # combine spectrographs
     drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="b", expnum=sci_expnum)
     drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="r", expnum=sci_expnum)
     drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="z", expnum=sci_expnum)

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -269,18 +269,18 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
         flux_tasks.fluxcal_Gaia(sci_camera, hsci_path, GAIA_CACHE_DIR=ORIG_MASTER_DIR+'/gaia_cache')
 
     # combine spectrographs
-    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="b", expnum=sci_expnum)
-    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="r", expnum=sci_expnum)
-    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="z", expnum=sci_expnum)
+    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="b", expnum=sci_expnum, imagetype=sci_imagetyp)
+    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="r", expnum=sci_expnum, imagetype=sci_imagetyp)
+    drp.combine_spectrographs(tileid=sci_tileid, mjd=sci_mjd, channel="z", expnum=sci_expnum, imagetype=sci_imagetyp)
 
     # flux-calibrate each channel
-    sci_paths = sorted(drp.path.expand("lvm_anc", drpver=drpver, tileid=sci_tileid, mjd=sci_mjd, kind="", imagetype="object", camera="*", expnum=sci_expnum))
-    sci_paths = [sci_path for sci_path in sci_paths if "lvm-object-sp" not in sci_path]
+    sci_paths = sorted(drp.path.expand("lvm_anc", drpver=drpver, tileid=sci_tileid, mjd=sci_mjd, kind="", imagetype=sci_imagetyp, camera="*", expnum=sci_expnum))
+    sci_paths = [sci_path for sci_path in sci_paths if f"lvm-{sci_imagetyp}-sp" not in sci_path]
     for sci_path in sci_paths:
         flux_tasks.apply_fluxcal(in_rss=sci_path, out_rss=sci_path)
 
     # combine channels
-    drp.combine_channels(tileid=sci_tileid, mjd=sci_mjd, expnum=sci_expnum)
+    drp.combine_channels(tileid=sci_tileid, mjd=sci_mjd, expnum=sci_expnum, imagetype=sci_imagetyp)
 
     # refine sky subtraction
     sky_tasks.quick_sky_refinement(in_cframe=path.full("lvm_frame", mjd=sci_mjd, drpver=drpver, tileid=sci_tileid, expnum=sci_expnum, kind='CFrame'))

--- a/python/lvmdrp/functions/skyMethod.py
+++ b/python/lvmdrp/functions/skyMethod.py
@@ -1698,6 +1698,9 @@ def quick_sky_refinement(in_cframe, band=np.array((7238,7242,7074,7084,7194,7265
     """
     
     cframe = fits.open(in_cframe)
+    if cframe[0].header["IMAGETYP"] != "object":
+        return
+
     wave = cframe["WAVE"].data
     flux = cframe["FLUX"].data
     error = cframe["ERROR"].data


### PR DESCRIPTION
This PR enables the reduction of calibration frames like twilights and lamp exposures with the `quick-reduction` script. The outputs still be the same as with the science reductions.