### PR TITLE
Fix pixel shifts in dome/twilight flat images

### DIFF
--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -212,6 +212,67 @@ def _bg_subtraction(images, quad_sections, bg_sections):
     return images_bgcorr, bg_images_med, bg_images_std, bg_sections
 
 
+def _fillin_valleys(data, width=18):
+    """fills in valleys in the data array
+
+    Parameters
+    ----------
+    data : array_like
+        1-dimensional array of data
+    width : int, optional
+        width of the valley to fill, by default 18
+
+    Returns
+    -------
+    array_like
+        1-dimensional array with filled valleys
+    """
+    data_out = copy(data)
+    top = data[0]
+    for i in range(data.size):
+        if data[i] > top:
+            top = data[i]
+        if data[i] == top:
+            continue
+        if data[i] < top:
+            j_ini = i
+        j_fin = j_ini
+        for j in range(j_ini, data.size):
+            if data[j] < top:
+                continue
+            if data[j] == top:
+                j_fin = j
+                break
+        if j_fin - j_ini < width:
+            data_out[j_ini:j_fin] = top
+    return data_out
+
+
+def _no_stepdowns(data):
+    """Removes stepdowns in the data array
+
+    Parameters
+    ----------
+    data : array_like
+        1-dimensional array of data
+
+    Returns
+    -------
+    array_like
+        1-dimensional array with stepdowns removed
+    """
+    data_out = copy(data)
+    top = data[0]
+    for i in range(data.size):
+        if data[i] > top:
+            top = data[i]
+        if data[i] == top:
+            continue
+        if data[i] < top:
+            data_out[i] = top
+    return data_out
+
+
 class Image(Header):
     def __init__(self, data=None, header=None, mask=None, error=None, origin=None, individual_frames=None, slitmap=None):
         Header.__init__(self, header=header, origin=origin)

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -56,6 +56,26 @@ def create_subplots(to_display, flatten_axes=True, **subplots_params):
     return fig, axs
 
 
+def plot_image_shift(ax, image, column_shift, pos=(0.0,1.0-0.32), box=(0.3,0.3), cmap="gray"):
+    """plots the pixel shifts of the given image along the given column shifts positions"""
+    xh = image.shape[1]//2
+    deltas = np.gradient(column_shift)
+    irows = np.where(deltas == 1)[0][::2][::-1]
+    axis = []
+    for i, irow in enumerate(irows):
+        iy, fy, ix, fx = xh-30, xh+30, irow-30, irow+30
+        axi = ax.inset_axes((pos[0],pos[1]-i/3.2, *box))
+        axi.imshow(image[ix:fx, iy:fy], extent=[iy,fy,ix,fx], origin="lower", cmap=cmap, vmin=0, vmax=np.mean(image)+3*np.std(image))
+        axi.tick_params(axis="both", labelsize=10)
+        if i == 0 and irows.size > 1:
+            axi.tick_params(axis="both", labelbottom=False)
+        else:
+            axi.set_xlabel("X (pixel)", fontsize=10)
+        axi.set_ylabel("Y (pixel)", fontsize=10)
+        axis.append(axi)
+    return axis
+
+
 def plot_image(
     image, ax, title=None, use_mask=True, labels=True, colorbar=True, extension="data"
 ):

--- a/python/lvmdrp/functions/imageMethod.py
+++ b/python/lvmdrp/functions/imageMethod.py
@@ -55,15 +55,7 @@ DEFAULT_TRIMSEC = [
     "[1:2043, 1:2040]",
     "[2078:4120, 1:2040]",
 ]
-# NOTE: this is the OS region shrinked down to avoid pixels with fiber signal
 DEFAULT_BIASSEC = [
-    "[2048:2058, 2041:4080]",
-    "[2065:2075, 2041:4080]",
-    "[2048:2058, 1:2040]",
-    "[2065:2075, 1:2040]",
-]
-# NOTE: original OS region
-ORI_BIASSEC = [
     "[2044:2060, 2041:4080]",
     "[2061:2077, 2041:4080]",
     "[2044:2060, 1:2040]",
@@ -3012,6 +3004,7 @@ def fix_pixel_shifts(in_image, ref_image, threshold=1.15, fill_gaps=20, display_
         log.info(f"calculating pixel shifts for {camera} quadrant {i+1} with OS counts ratio >{threshold}")
         shift_mask = numpy.abs(os_quad._data / os_quad_r._data) > threshold
         shift_pixels_raw = numpy.sum(shift_mask, axis=1)
+        log.info(f"found {(shift_pixels_raw>0).sum()} rows shifted")
 
         # fix hair
         hairs = (shift_pixels_raw % 2).astype(bool)

--- a/python/lvmdrp/functions/imageMethod.py
+++ b/python/lvmdrp/functions/imageMethod.py
@@ -32,11 +32,13 @@ from lvmdrp.core.image import (
     Image,
     _parse_ccd_section,
     _model_overscan,
+    _fillin_valleys,
+    _no_stepdowns,
     combineImages,
     glueImages,
     loadImage,
 )
-from lvmdrp.core.plot import plt, create_subplots, plot_detrend, plot_strips, save_fig
+from lvmdrp.core.plot import plt, create_subplots, plot_detrend, plot_strips, plot_image_shift, save_fig
 from lvmdrp.core.rss import RSS
 from lvmdrp.core.spectrum1d import Spectrum1D, _spec_from_lines, _cross_match
 from lvmdrp.core.tracemask import TraceMask
@@ -2952,6 +2954,72 @@ def testres_drp(image, trace, fwhm, flux):
     hdu = pyfits.PrimaryHDU((img._data - out) / img._data)
     hdu.writeto("res_rel.fits", overwrite=True)
 
+
+def fix_pixel_shifts(in_image, out_image, ref_image, threshold=1.15, fill_gaps=20, display_plots=False):
+
+    # load reference image
+    image_ref = Image()
+    image_ref.loadFitsData(ref_image)
+
+    # load input image
+    image = Image()
+    image.loadFitsData(in_image)
+    image_out = copy(image)
+
+    # get useful metadata
+    mjd, expnum, camera = image._header["MJD"], image._header["EXPOSURE"], image._header["CCD"]
+
+    sc_sections, os_sections = list(image._header["TRIMSEC?"].values()), list(image._header["BIASSEC?"].values())
+    shifts = []
+    for i, (sc_sec, os_sec) in enumerate(zip(sc_sections, os_sections)):
+        # get overscan quadrant
+        os_quad_r = image_ref.getSection(os_sec)
+        os_quad = image.getSection(os_sec)
+
+        # calculate pixels to shift and amount of shifting
+        shift_mask = numpy.abs(os_quad._data / os_quad_r._data) > threshold
+        shift_pixels_raw = numpy.sum(shift_mask, axis=1)
+
+        # fix hair
+        hairs = (shift_pixels_raw % 2).astype(bool)
+        shift_pixels_raw[hairs] -= 1
+        shift_pixels_raw[shift_pixels_raw < 0] = 0
+
+        # interpolate valleys
+        shift_pixels = _fillin_valleys(shift_pixels_raw, width=fill_gaps)
+        shifts.append(shift_pixels)
+
+    # decide on the shift direction
+    shift_right = numpy.concatenate(shifts[1::2][::-1])
+    shift_left = -1*numpy.concatenate(shifts[::2][::-1])
+    if numpy.any(shift_right != 0):
+        shift_column = shift_right
+    else:
+        shift_column = shift_left
+
+    # correct stepdowns
+    shift_column = _no_stepdowns(shift_column)
+
+    # apply shifts and write output image
+    if numpy.any(shift_column != 0):
+        for irow in range(image._data.shape[0]):
+            image_out._data[irow] = numpy.roll(image._data[irow], shift_column[irow])
+        image_out.writeFitsData(out_image)
+
+    # display plots if requested
+    if display_plots and numpy.any(shift_column != 0):
+        fig, ax = plt.subplots(figsize=(15,7), sharex=True, layout="constrained")
+        ax.set_title(f"{mjd = } - {expnum = } - {camera = }", loc="left")
+        y_pixels = numpy.arange(shift_column.size)
+        ax.step(y_pixels, shift_column, where="mid", lw=1)
+        ax.set_xlabel("Y (pixel)")
+        ax.set_ylabel("Shift (pixel)")
+        plot_image_shift(ax, image._data, shift_column, cmap="Reds")
+        axis = plot_image_shift(ax, image_out._data, shift_column, cmap="Blues", pos=(0.14,1.0-0.32))
+        plt.setp(axis, yticklabels=[], ylabel="")
+
+    return shift_column, image_out
+
 # TODO: for arcs take short exposures for bright lines & long exposures for faint lines
 # TODO: Argon: 10s + 300s
 # TODO: Neon: 10s + 300s
@@ -3059,24 +3127,24 @@ def preproc_raw_frame(
     # extract TRIMSEC or assume default value
     if assume_trimsec:
         log.info(f"using given TRIMSEC = {assume_trimsec}")
-        sc_sec = [sec for sec in assume_trimsec]
+        sc_sections = [sec for sec in assume_trimsec]
     elif not org_header["TRIMSEC?"]:
         log.warning(f"assuming TRIMSEC = {DEFAULT_TRIMSEC}")
-        sc_sec = DEFAULT_TRIMSEC
+        sc_sections = DEFAULT_TRIMSEC
     else:
-        sc_sec = list(org_header["TRIMSEC?"].values())
-        log.info(f"using header TRIMSEC = {sc_sec}")
+        sc_sections = list(org_header["TRIMSEC?"].values())
+        log.info(f"using header TRIMSEC = {sc_sections}")
 
     # extract BIASSEC or assume default value
     if assume_biassec:
         log.info(f"using given BIASSEC = {assume_biassec}")
-        os_sec = [sec for sec in assume_biassec]
+        os_sections = [sec for sec in assume_biassec]
     elif not org_header["BIASSEC?"]:
         log.warning(f"assuming BIASSEC = {DEFAULT_BIASSEC}")
-        os_sec = DEFAULT_BIASSEC
+        os_sections = DEFAULT_BIASSEC
     else:
-        os_sec = list(org_header["BIASSEC?"].values())
-        log.info(f"using header BIASSEC = {os_sec}")
+        os_sections = list(org_header["BIASSEC?"].values())
+        log.info(f"using header BIASSEC = {os_sections}")
 
     # extract gain
     gain = numpy.ones(NQUADS)
@@ -3094,7 +3162,7 @@ def preproc_raw_frame(
     sc_quads, os_quads = [], []
     os_profiles, os_models = [], []
     # process each quadrant
-    for i, (sc_xy, os_xy) in enumerate(zip(sc_sec, os_sec)):
+    for i, (sc_xy, os_xy) in enumerate(zip(sc_sections, os_sections)):
         # get overscan and science quadrant & convert to electron
         sc_quad = org_img.getSection(section=sc_xy)
         os_quad = org_img.getSection(section=os_xy)
@@ -3258,7 +3326,7 @@ def preproc_raw_frame(
             sg_stat=lambda x, axis: numpy.nanmedian(numpy.std(x, axis=axis)),
             labels=True,
         )
-        os_x, os_y = _parse_ccd_section(list(os_sec)[0])
+        os_x, os_y = _parse_ccd_section(list(os_sections)[0])
         axs[i].axvline(os_x[1] - os_x[0], ls="--", color="0.5", lw=1)
         axs[i].set_title(f"overscan for quadrants {['12','34'][i]}", loc="left")
     save_fig(
@@ -3294,7 +3362,7 @@ def preproc_raw_frame(
             show_individuals=True,
             labels=True,
         )
-        os_x, os_y = _parse_ccd_section(list(os_sec)[0])
+        os_x, os_y = _parse_ccd_section(list(os_sections)[0])
         axs[i].axvline(os_y[1] - os_y[0], ls="--", color="0.5", lw=1)
         axs[i].set_title(f"overscan for quadrants {['13','24'][i]}", loc="left")
     save_fig(

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -215,7 +215,7 @@ def _get_ring_expnums(expnums_ldls, expnums_qrtz, ring_size=12, sort_expnums=Fal
     return expnum_params
 
 
-def reduce_2d(mjds, target_mjd=None, expnums=None):
+def reduce_2d(mjds, target_mjd=None, expnums=None, ref_expnum=None):
     """Preprocess and detrend a list of 2D frames
 
     Given a set of MJDs and (optionally) exposure numbers, preprocess and
@@ -231,6 +231,8 @@ def reduce_2d(mjds, target_mjd=None, expnums=None):
         MJD to store the master frames in
     expnums : list
         List of exposure numbers to reduce
+    ref_expnum : int
+        Reference exposure number for pixel shift correction
     """
 
     frames, masters_mjd = get_sequence_metadata(mjds, target_mjd=target_mjd, expnums=expnums)
@@ -254,6 +256,8 @@ def reduce_2d(mjds, target_mjd=None, expnums=None):
         log.info(f'Using master pixel flat: {mpixflat_path}')
 
         frame_path = path.full("lvm_raw", camspec=frame["camera"], **frame)
+        if ref_expnum is not None:
+            ref_path = path.full("lvm_raw", hemi=frame["hemi"], mjd=frame["mjd"], camspec=frame["camera"], expnum=ref_expnum)
         pframe_path = path.full("lvm_anc", drpver=drpver, kind="p", imagetype=imagetyp, **frame)
 
         # bypass creation of detrended frame in case of imagetyp=bias
@@ -266,6 +270,8 @@ def reduce_2d(mjds, target_mjd=None, expnums=None):
         if os.path.isfile(dframe_path):
             log.info(f"skipping {dframe_path}, file already exist")
         else:
+            if frame["imagetyp"] == "flat" and ref_expnum is not None:
+                image_tasks.fix_pixel_shifts(in_image=frame_path, ref_image=ref_path)
             image_tasks.preproc_raw_frame(in_image=frame_path, out_image=pframe_path, in_mask=mpixmask_path)
             image_tasks.detrend_frame(in_image=pframe_path, out_image=dframe_path,
                                         in_bias=mbias_path, in_dark=mdark_path,

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -461,7 +461,7 @@ def resample_fiberflat(mflat: RSS, camera: str, mwave_path: str,
 
     return new_flat
 
-def reduce_twilight_sequence(expnums: List[int], median_box: int = 10, niter: bool = 1000,
+def reduce_twilight_sequence(expnums: List[int], ref_expnum: int, median_box: int = 10, niter: bool = 1000,
                              threshold: Tuple[float,float]|float = (0.5,1.5), nknots: bool = 50,
                              b_mask: List[Tuple[float,float]] = MASK_BANDS["b"],
                              r_mask: List[Tuple[float,float]] = MASK_BANDS["r"],
@@ -477,6 +477,8 @@ def reduce_twilight_sequence(expnums: List[int], median_box: int = 10, niter: bo
     ----------
     expnums : list
         List of twilight exposure numbers
+    ref_expnum : int
+        Reference exposure number to fix pixel shifts
     median_box : int, optional
         Size of the median filter box, by default 5
     niter : int, optional
@@ -523,6 +525,7 @@ def reduce_twilight_sequence(expnums: List[int], median_box: int = 10, niter: bo
         }
 
         flat_path = path.full("lvm_raw", camspec=flat["camera"], **flat)
+        ref_flat_path = path.full("lvm_raw", hemi=flat["hemi"], mjd=flat["mjd"], camspec=flat["camera"], expnum=ref_expnum)
         pflat_path = path.full("lvm_anc", drpver=drpver, kind="p", imagetype=flat["imagetyp"], **flat)
         dflat_path = path.full("lvm_anc", drpver=drpver, kind="d", imagetype=flat["imagetyp"], **flat)
         lflat_path = path.full("lvm_anc", drpver=drpver, kind="l", imagetype=flat["imagetyp"], **flat)
@@ -532,6 +535,8 @@ def reduce_twilight_sequence(expnums: List[int], median_box: int = 10, niter: bo
         if skip_done and os.path.isfile(dflat_path):
             log.info(f"skipping {dflat_path}, file already exist")
         else:
+            if ref_expnum is not None:
+                imageMethod.fix_pixel_shifts(in_image=flat_path, ref_image=ref_flat_path)
             imageMethod.preproc_raw_frame(in_image=flat_path, out_image=pflat_path, in_mask=master_cals.get("pixelmask"))
             imageMethod.detrend_frame(in_image=pflat_path, out_image=dflat_path,
                                         in_bias=master_cals.get("bias"), in_dark=master_cals.get("dark"),

--- a/tests/core/test_image.py
+++ b/tests/core/test_image.py
@@ -1,52 +1,22 @@
 
 import pytest
 import numpy as np
-from astropy.io import fits
 
-from lvmdrp.core.image import Image, _parse_ccd_section, _model_overscan
-from lvmdrp.functions.imageMethod import DEFAULT_BIASSEC, DEFAULT_TRIMSEC
-
-
-def create_fake_raw(path, tileid=11111, mjd=61234, expnum=6817, cameras=None, leak=True):
-    """ create a fake raw frame FITS file """
-    out = {}
-    cameras = cameras or ['b1']
-    for cam in cameras:
-        # create fake header
-        filename = f'sdR-s-{cam}-{expnum:0>8}.fits.gz'
-        hdr = {'TILE_ID': tileid, 'MJD': mjd, 'EXPOSURE': expnum, "CCD": cam,
-               'EXPTIME': 900.0,
-               'IMAGETYP': 'object', 'FILENAME': filename, 'SPEC': f'sp{cam[-1]}',
-               'OBSTIME': '2023-10-18T07:56:23.289', 'OBSERVAT': 'LCO',
-               'TELESCOP': 'SDSS 0.16m', 'SURVEY': 'LVM'}
-
-        # mock data
-        data = np.zeros((4080, 4120), dtype=int)
-        bias_levels = [980, 960, 1000, 1020]
-        sci_level = 10000
-        for iquad in range(4):
-            (os_ix,os_fx), (os_iy,os_fy) = _parse_ccd_section(DEFAULT_BIASSEC[iquad])
-            (sc_ix,sc_fx), (sc_iy,sc_fy) = _parse_ccd_section(DEFAULT_TRIMSEC[iquad])
-            data[os_iy:os_fy, os_ix:os_fx] += bias_levels[iquad]
-            data[sc_iy:sc_fy, sc_ix:sc_fx] += bias_levels[iquad] + sci_level
-            if leak:
-                data[:, (os_ix if iquad in {0,2} else os_fx-1)] += sci_level
-        prim = fits.PrimaryHDU(header=fits.Header(hdr), data=data)
-
-        # create fake file
-        full = path / filename
-        hdulist = fits.HDUList(prim)
-        hdulist.writeto(full)
-        out[cam] = full
-    return out, bias_levels, sci_level
+from lvmdrp import path
+from lvmdrp.core.image import Image, _model_overscan
+from lvmdrp.functions.imageMethod import DEFAULT_BIASSEC
 
 
-def test_model_overscan_nomasking(datadir):
+def test_model_overscan_nomasking(make_fits):
     mjd = 61231
-    paths = datadir([mjd])
-    name, bias_levels, sci_level = create_fake_raw(paths[0], mjd=mjd, cameras=['b1'], expnum=0)
+    bias_levels = [980, 960, 1000, 1020]
+    sci_level = 100000
+    make_fits(mjd=mjd, cameras=['b1'], expnum=0, bias_levels=bias_levels, sci_level=sci_level)
+    ipath = path.full("lvm_raw", hemi="s", camspec="b1", mjd=61231, expnum=0)
+
     image = Image()
-    image.loadFitsData(str(name['b1']))
+    image.loadFitsData(ipath)
+
     for iquad in range(4):
         os_quad = image.getSection(DEFAULT_BIASSEC[iquad])
         masked_data, profile, model = _model_overscan(os_quad, axis=1, threshold=None)
@@ -54,15 +24,19 @@ def test_model_overscan_nomasking(datadir):
         assert model == pytest.approx(np.ones_like(model) * bias_levels[iquad], abs=2)
 
 
-def test_model_overscan_masking(datadir):
+def test_model_overscan_masking(make_fits):
     mjd = 61231
-    paths = datadir([mjd])
-    name, bias_levels, sci_level = create_fake_raw(paths[0], mjd=mjd, cameras=['b1'], leak=True, expnum=1)
+    bias_levels = [980, 960, 1000, 1020]
+    sci_level = 100000
+    make_fits(mjd=mjd, cameras=['b1'], expnum=1, bias_levels=bias_levels, sci_level=sci_level, leak=True)
+    ipath = path.full("lvm_raw", hemi="s", camspec="b1", mjd=61231, expnum=1)
+
     image = Image()
-    image.loadFitsData(str(name['b1']))
+    image.loadFitsData(ipath)
+
     for iquad in range(4):
         os_quad = image.getSection(DEFAULT_BIASSEC[iquad])
-        masked_data, profile, model = _model_overscan(os_quad, axis=1, threshold=1.0)
+        masked_data, profile, model = _model_overscan(os_quad, axis=1, threshold=3.0)
         assert profile == pytest.approx(np.ones_like(profile) * bias_levels[iquad], abs=2)
         assert model == pytest.approx(np.ones_like(model) * bias_levels[iquad], abs=2)
         assert np.isnan(masked_data).sum() == profile.size

--- a/tests/functions/test_imageMethod.py
+++ b/tests/functions/test_imageMethod.py
@@ -1,0 +1,36 @@
+
+import numpy as np
+
+from lvmdrp import path
+from lvmdrp.core.image import Image
+from lvmdrp.functions import imageMethod
+
+
+def test_fix_pixel_shifts_noshift(make_fits):
+    make_fits(mjd=61231, cameras=['b1'], expnum=3, leak=False, shift_rows=[])
+    make_fits(mjd=61231, cameras=['b1'], expnum=4, leak=False, shift_rows=[])
+    rpath = path.full("lvm_raw", hemi="s", camspec="b1", mjd=61231, expnum=3)
+    ipath = path.full("lvm_raw", hemi="s", camspec="b1", mjd=61231, expnum=4)
+
+    image_ori = Image()
+    image_ori.loadFitsData(ipath)
+    shift_columns, image_fixed = imageMethod.fix_pixel_shifts(in_image=ipath, ref_image=rpath)
+
+    assert (shift_columns == 0).all()
+    assert (image_fixed._data == image_ori._data).all()
+
+
+def test_fix_pixel_shifts(make_fits):
+    make_fits(mjd=61231, cameras=['b1'], expnum=5, leak=False, shift_rows=[])
+    make_fits(mjd=61231, cameras=['b1'], expnum=6, leak=False, shift_rows=[1500])
+    rpath = path.full("lvm_raw", hemi="s", camspec="b1", mjd=61231, expnum=5)
+    ipath = path.full("lvm_raw", hemi="s", camspec="b1", mjd=61231, expnum=6)
+
+    image_ori = Image()
+    image_ori.loadFitsData(rpath)
+    shift_columns, image_fixed = imageMethod.fix_pixel_shifts(in_image=ipath, ref_image=rpath)
+    expected_shifts = np.zeros_like(shift_columns)
+    expected_shifts[1500:] = 2
+
+    assert (shift_columns == expected_shifts).all()
+    assert (image_fixed._data == image_ori._data).all()

--- a/tests/utils/test_metadata.py
+++ b/tests/utils/test_metadata.py
@@ -20,6 +20,7 @@ def mock_meta():
 
 def test_get_frames_metadata(make_fits):
     """ test we can extract metadata from a fits file """
+    make_fits(mjd=61234, cameras=['b1', 'b2', 'b3'], expnum=6817)
     meta = get_frames_metadata(61234)
     meta = meta.sort_values('camera')
     assert len(meta) == 3


### PR DESCRIPTION
Implementing fix for pixel shifts detected in dome/twilight flats. Main changes are:

- Implementing detection of pixel shifts and corrections
- Implementing function to plot a image around pixel shifts
- Added as new pipeline step with the condition `imagetyp=='flat'`