### PR TITLE
Fixes crash when exposures missing spectrographs/channels.  

### DIFF
--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -2889,7 +2889,11 @@ def stack_spectrographs(in_rsss: List[str], out_rss: str) -> RSS:
     rsss = [loadRSS(in_rss) for in_rss in in_rsss]
 
     log.info(f"stacking frames in {','.join([os.path.basename(in_rss) for in_rss in in_rsss])} along fiber ID axis")
-    rss_out = RSS.from_spectrographs(*rsss)
+    try:
+        rss_out = RSS.from_spectrographs(*rsss)
+    except TypeError as e:
+        log.error(f'Cannot stack spectrographs: {e}')
+        return
 
     # write output
     log.info(f"writing stacked RSS to {os.path.basename(out_rss)}")

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -189,6 +189,9 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
 
         # stack spectrographs
         rss_tasks.stack_spectrographs(in_rsss=xsci_paths, out_rss=xsci_path)
+        if not os.path.exists(xsci_path):
+            log.error(f'No stacked file found: {xsci_path}. Skipping remaining pipeline.')
+            continue
 
         # wavelength calibrate
         rss_tasks.create_pixel_table(in_rss=xsci_path, out_rss=wsci_path, in_waves=mwave_paths, in_lsfs=mlsf_paths)
@@ -214,6 +217,10 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
 
     # stitch channels
     fframe_paths = sorted(path.expand('lvm_frame', mjd=sci_mjd, tileid=sci_tileid, drpver=drpver, kind='FFrame-?', expnum=expnum))
+    if len(fframe_paths) == 0:
+        log.error('No fframe files found.  Cannot join spectrograph channels. Exiting pipeline.')
+        return
+
     cframe_path = path.full("lvm_frame", drpver=drpver, tileid=sci_tileid, mjd=sci_mjd, expnum=sci_expnum, kind='CFrame')
     rss_tasks.join_spec_channels(in_rsss=fframe_paths, out_rss=cframe_path, use_weights=True)
 


### PR DESCRIPTION
This PR fixes an issue where the DRP crashes when an exposure doesn't have all spectrograph or channels.  The original errors were seen in https://data.sdss5.org/sas/sdsswork/lvm/spectro/redux/master/drp_errors.txt. For example, 
```
ERROR on tileid, mjd, exposure: 1028742, 60216, 5755
Traceback (most recent call last):
  File "/uufs/chpc.utah.edu/common/home/sdss50/software/git/sdss/lvmdrp/master/python/lvmdrp/functions/run_drp.py", line 1523, in run_drp
    quick_science_reduction(expnum, use_fiducial_master=True)
  File "/uufs/chpc.utah.edu/common/home/sdss50/software/git/sdss/lvmdrp/master/python/lvmdrp/functions/run_quickdrp.py", line 279, in quick_science_reduction
    flux_tasks.apply_fluxcal(in_rss=sci_path, out_rss=sci_path)
  File "/uufs/chpc.utah.edu/common/home/sdss50/software/git/sdss/lvmdrp/master/python/lvmdrp/functions/fluxCalMethod.py", line 164, in apply_fluxcal
    rss._data *= sens_ave * 10**(0.4*ext*(sci_secz)) / exptimes[:, None]
ValueError: operands could not be broadcast together with shapes (1296,4401) (1944,4401) (1296,4401) 
```  

These errors were from the old pipeline.  When running on the latest `master`, I would get the following crash
```
[INFO]: stacking frames in lvm-xobject-b1-00008544.fits,lvm-xobject-b2-00008544.fits along fiber ID axis
[ERROR]: Failed to reduce science frame mjd 60278 exposure 8544: RSS.from_spectrographs() missing 1 required positional argument: 'rss_sp3'
Traceback (most recent call last):
  File "/Users/brian/Work/git/sdss/lvmdrp/python/lvmdrp/functions/run_drp.py", line 1530, in run_drp
    quick_science_reduction(expnum, use_fiducial_master=True, **kwargs)
  File "/Users/brian/Work/git/sdss/lvmdrp/python/lvmdrp/functions/run_quickdrp.py", line 191, in quick_science_reduction
    rss_tasks.stack_spectrographs(in_rsss=xsci_paths, out_rss=xsci_path)
  File "/Users/brian/Work/git/sdss/lvmdrp/python/lvmdrp/functions/rssMethod.py", line 2892, in stack_spectrographs
    rss_out = RSS.from_spectrographs(*rsss)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: RSS.from_spectrographs() missing 1 required positional argument: 'rss_sp3'
```

Comparing the errors in the file with the observing log, they all seem to be cases where not all spectrographs or channels were taken during the night.  This PR fixes the crashes so the pipeline exits gracefully now with the following:

```
[INFO]: writing extracted spectra to lvm-xobject-b2-00008544.fits
[INFO]: stacking frames in lvm-xobject-b1-00008544.fits,lvm-xobject-b2-00008544.fits along fiber ID axis
[ERROR]: Cannot stack spectrographs: RSS.from_spectrographs() missing 1 required positional argument: 'rss_sp3'
[ERROR]: No stacked file found: /Users/brian/Work/sdss/sas/sdsswork/lvm/spectro/redux/0.1.2dev/1041XX/1041497/60278/ancillary/lvm-xobject-b-00008544.fits. Skipping remaining pipeline.
[INFO]: stacking frames in  along fiber ID axis
[ERROR]: Cannot stack spectrographs: RSS.from_spectrographs() missing 3 required positional arguments: 'rss_sp1', 'rss_sp2', and 'rss_sp3'
[ERROR]: No stacked file found: /Users/brian/Work/sdss/sas/sdsswork/lvm/spectro/redux/0.1.2dev/1041XX/1041497/60278/ancillary/lvm-xobject-r-00008544.fits. Skipping remaining pipeline.
[INFO]: stacking frames in  along fiber ID axis
[ERROR]: Cannot stack spectrographs: RSS.from_spectrographs() missing 3 required positional arguments: 'rss_sp1', 'rss_sp2', and 'rss_sp3'
[ERROR]: No stacked file found: /Users/brian/Work/sdss/sas/sdsswork/lvm/spectro/redux/0.1.2dev/1041XX/1041497/60278/ancillary/lvm-xobject-z-00008544.fits. Skipping remaining pipeline.
[ERROR]: No fframe files found.  Cannot join spectrograph channels. Exiting pipeline.
```

