### PR TITLE
Adds new cli for submitting utah cluster run

### DIFF
--- a/bin/drp
+++ b/bin/drp
@@ -11,9 +11,10 @@ import click
 import cloup
 from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
 
-from lvmdrp.functions.run_drp import run_drp, reduce_file, check_daily_mjd
+from lvmdrp.functions.run_drp import run_drp, reduce_file, check_daily_mjd, parse_mjds
 from lvmdrp.functions.skyMethod import configureSkyModel_drp
 from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
+from lvmdrp.utils.cluster import run_cluster
 
 from lvmdrp.functions.run_quickdrp import quick_science_reduction
 from lvmdrp.functions.run_twilights import reduce_twilight_sequence, MASK_BANDS
@@ -223,6 +224,26 @@ def erase(drpver: str):
         click.echo(f'Path {path} does not exist.')
         return
     shutil.rmtree(path)
+
+
+@cli.command('cluster', short_help='Submit a Utah cluster run')
+@click.option('-l', '--mjd-list', type=int, default=None, multiple=True, help='a list of specific MJDs to reduce')
+@click.option('-r', '--mjd-range', type=str, default=None, help='a range of MJDs to reduce')
+@click.option('-n', '--nodes', type=int, default=2, help='the number of nodes to use')
+@click.option('-p', '--ppn', type=int, default=64, help='the number of CPU cores to use per node')
+@click.option('-w', '--walltime', type=str, default="24:00:00", help='the time for which the job is allowed to run')
+@click.option('-a', '--alloc', type=click.Choice(['sdss-np', 'sdss-kp']), default='sdss-np', help='which partition to use')
+@click.option('-s', '--submit', type=bool, default=True, help='flag to submit the job or not')
+def cluster(mjd_list, mjd_range, nodes, ppn, walltime, alloc, submit):
+    """ Submit a Utah cluster job to batch run the DRP by MJD """
+
+    # filter the mjds
+    mjds = mjd_list or mjd_range or None
+    if mjds:
+        mjds = parse_mjds(mjds)
+
+    # submit the cluster job
+    run_cluster(mjds=mjds, nodes=nodes, ppn=ppn, walltime=walltime, alloc=alloc, submit=submit)
 
 
 if __name__ == "__main__":

--- a/python/lvmdrp/utils/cluster.py
+++ b/python/lvmdrp/utils/cluster.py
@@ -1,0 +1,63 @@
+
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os
+
+from lvmdrp import log
+
+try:
+    from slurm import queue
+except ImportError:
+    queue = None
+
+
+
+def run_cluster(mjds: list = None, nodes: int = 2, ppn: int = 64, walltime: str = '24:00:00',
+                alloc: str = 'sdss-np', submit: bool = True):
+    """ Submit a slurm cluster Utah job
+
+    Creates the cluster job at $SLURM_SCRATCH_DIR, e.g /scratch/general/nfs1/[unid]/pbs
+    in a sub-directory of the job label, e.g. "lvm_cluster_run", with job id, i.e.
+    "/scratch/general/nfs1/[unid]/pbs/[label]/[jobid]".  Logs are available at
+    $SLURM_LOGS_DIR.  The cluster adopts the environment from which the cluster job
+    was submitted.
+
+    This requires the specific module "slurm/notchpeak-pipelines" to be loaded, and the
+    following package versions installed in the Utah miniconda environment:
+    flask==2.1.2 flask-sqlalchemy==2.5.1 werkzeug==2.0.1 sqlalchemy==1.4.23
+
+    Parameters
+    ----------
+    mjds : list, optional
+        a list of MJDs to submit to the cluster
+    nodes : int, optional
+        the number of nodes to use, by default 2
+    ppn : int, optional
+        the number of CPU cores per node, by default 64
+    walltime : str, optional
+        the time of which the job is allowed to run, by default '24:00:00'
+    alloc : str, optional
+        which partition to use, by default 'sdss-np'
+    submit : bool, optional
+        Flag to submit the job or not, by default True
+    """
+
+    if not queue:
+        log.error('No slurm queue module available.  Cannot submit cluster run.')
+        return
+
+    # get a list of mjds
+    mjds = mjds or sorted(os.listdir(os.getenv('LVM_DATA_S')))
+
+    # create the slurm queue
+    q = queue()
+    q.verbose = True
+    q.create(label='lvm_cluster_run', nodes=nodes, ppn=ppn, walltime=walltime, alloc=alloc, shared=True)
+
+    for mjd in mjds:
+        script = f"drp run -m {mjd}"
+        q.append(script)
+
+    # submit the queue
+    q.commit(hard=True, submit=submit)


### PR DESCRIPTION
This PR adds a new function, `run_cluster`, and new CLI `drp cluster` to submit a slurm job to the Utah cluster.  it parallelizes the DRP run around MJDs, with the command `drp run -m MJD`.  It accepts options for submitting only a list of MJDs or an MJD range.  If not specified, will default to all MJDs in the LVM_DATA_S directory.  

This has been tested at Utah without submitting.  It still needs to be tested on the cluster to check things run properly. 

