### PR TITLE
Waveshift

### DIFF
--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -745,9 +745,10 @@ def shift_wave_skylines(in_rss: str, out_rss: str, channel: str):
         Output RSS FITS file with the shifted wavelength maps
     """
 
-    print('************************************************')
-    print('***** CORRECTING WAVELENGTH USING SKYLINES *****')
-    print('************************************************')
+    # print('************************************************')
+    # print('***** CORRECTING WAVELENGTH USING SKYLINES *****')
+    # print('************************************************')
+    log.info("correcting wavelength using skylines")
 
 
     # GB hand picked isolated bright lines across each channel which are not doublest in UVES atlas
@@ -777,13 +778,13 @@ def shift_wave_skylines(in_rss: str, out_rss: str, channel: str):
 
     #Average offsets for different skylines in each channel, apply to trace, and write them in header
     meanoffset=numpy.nanmean(specoffset, axis=0)
-    print('Applying the following offsets [Angstroms] in [b,r,z] channels:', meanoffset)
+    log.info(f'Applying the following offsets [Angstroms] in [b,r,z] channels: {meanoffset}')
     rss._wave_trace['COEFF'].data[sel1,0] -= meanoffset[0]
     rss._wave_trace['COEFF'].data[sel2,0] -= meanoffset[1]
     rss._wave_trace['COEFF'].data[sel3,0] -= meanoffset[2]
-    rss._header[f'SKYOFF_{channel}1']=(f'{meanoffset[0]}', f'Mean sky line offset in {channel}1 [Angs]')
-    rss._header[f'SKYOFF_{channel}2']=(f'{meanoffset[1]}', f'Mean sky line offset in {channel}2 [Angs]')
-    rss._header[f'SKYOFF_{channel}3']=(f'{meanoffset[2]}', f'Mean sky line offset in {channel}3 [Angs]')
+    rss._header[f'HIERARCH WAVE SKYOFF_{channel}1']=(f'{meanoffset[0]}', f'Mean sky line offset in {channel}1 [Angs]')
+    rss._header[f'HIERARCH WAVE SKYOFF_{channel}2']=(f'{meanoffset[1]}', f'Mean sky line offset in {channel}2 [Angs]')
+    rss._header[f'HIERARCH WAVE SKYOFF_{channel}3']=(f'{meanoffset[2]}', f'Mean sky line offset in {channel}3 [Angs]')
 
     #write updated wobject
     log.info(f"writing updated wobject file '{os.path.basename(out_rss)}'")
@@ -791,32 +792,32 @@ def shift_wave_skylines(in_rss: str, out_rss: str, channel: str):
 
     # Make QA plots showing offsets for each sky line in each channel
     for i in range(len(skylines)):
-        fig, ax = plt.subplots() 
+        fig, ax = plt.subplots()
         ax.plot(fiberid[sel1], offsets[i,sel1], label='Spec1', color='red', alpha=0.5)
-        ax.plot(fiberid[sel2], offsets[i,sel2], label='Spec2', color='green', alpha=0.5)   
+        ax.plot(fiberid[sel2], offsets[i,sel2], label='Spec2', color='green', alpha=0.5)
         ax.plot(fiberid[sel3], offsets[i,sel3], label='Spec3', color='blue', alpha=0.5)
-        ax.plot(fiberid[sel1], numpy.repeat(specoffset[i,0], len(fiberid[sel1])), linestyle='--', color='red')   
-        ax.plot(fiberid[sel2], numpy.repeat(specoffset[i,1], len(fiberid[sel2])), linestyle='--', color='green')   
-        ax.plot(fiberid[sel3], numpy.repeat(specoffset[i,2], len(fiberid[sel3])), linestyle='--', color='blue')   
-        ax.plot(fiberid[sel1], numpy.repeat(meanoffset[0], len(fiberid[sel1])), linestyle='-', color='red')   
-        ax.plot(fiberid[sel2], numpy.repeat(meanoffset[1], len(fiberid[sel2])), linestyle='-', color='green')   
-        ax.plot(fiberid[sel3], numpy.repeat(meanoffset[2], len(fiberid[sel3])), linestyle='-', color='blue')   
-        ax.hlines(0, 0, 1944, linestyle='--', color='black', alpha=0.3)   
-        ax.hlines(+0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)   
-        ax.hlines(-0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)   
+        ax.plot(fiberid[sel1], numpy.repeat(specoffset[i,0], len(fiberid[sel1])), linestyle='--', color='red')
+        ax.plot(fiberid[sel2], numpy.repeat(specoffset[i,1], len(fiberid[sel2])), linestyle='--', color='green')
+        ax.plot(fiberid[sel3], numpy.repeat(specoffset[i,2], len(fiberid[sel3])), linestyle='--', color='blue')
+        ax.plot(fiberid[sel1], numpy.repeat(meanoffset[0], len(fiberid[sel1])), linestyle='-', color='red')
+        ax.plot(fiberid[sel2], numpy.repeat(meanoffset[1], len(fiberid[sel2])), linestyle='-', color='green')
+        ax.plot(fiberid[sel3], numpy.repeat(meanoffset[2], len(fiberid[sel3])), linestyle='-', color='blue')
+        ax.hlines(0, 0, 1944, linestyle='--', color='black', alpha=0.3)
+        ax.hlines(+0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)
+        ax.hlines(-0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)
         ax.legend()
         ax.set_ylim(-0.4,0.4)
         ax.set_title(f'{rss._header["EXPOSURE"]} - {channel} - {skylines[i]}')
         ax.set_xlabel('Fiber ID')
         ax.set_ylabel(r'$\Delta \lambda [\AA]$')
-    
+
         save_fig(
         fig,
         product_path=out_rss,
         to_display=False,
         figure_path="qa",
         label=f"skylineshift_{skylines[i]}")
-    
+
 
 
 # TODO:

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -731,6 +731,102 @@ def determine_wavelength_solution(in_arcs: List[str], out_wave: str, out_lsf: st
     fwhm_trace.writeFitsData(out_lsf)
 
 
+
+# method to apply shift in wavelength table based on comparison to skylines
+def shift_wave_skylines(in_rss: str, out_rss: str, channel: str):
+    """
+    Applies shift to wavelength map extension based on sky line centroid measurements
+
+    Parameters
+    ----------
+    in_rss : string
+        Input RSS FITS file
+    out_rss : string
+        Output RSS FITS file with the shifted wavelength maps
+    """
+
+    print('************************************************')
+    print('***** CORRECTING WAVELENGTH USING SKYLINES *****')
+    print('************************************************')
+
+
+    # GB hand picked isolated bright lines across each channel which are not doublest in UVES atlas
+    # true wavelengths taken from UVES sky line atlas
+    skylinedict={'b':[5577.346680], 'r':[6363.782715, 7358.680176, 7392.209961], 'z':[8399.175781, 8988.383789, 9552.546875, 9719.838867]}
+    skylines=skylinedict[channel]
+    dwave=5 # width of wavelength window to measure centroid of skylines
+
+    rss = RSS.from_file(in_rss)
+    fiberid=rss._slitmap['fiberid'].data
+    # selection of which fibers belong to which spectrograph
+    sel1=rss._slitmap['spectrographid'].data==1
+    sel2=rss._slitmap['spectrographid'].data==2
+    sel3=rss._slitmap['spectrographid'].data==3
+
+    # measure offsets
+    offsets=numpy.zeros((len(skylines), numpy.shape(rss._data)[0]))
+    specoffset=numpy.zeros((len(skylines), 3))
+    for i in range(len(skylines)):
+        mask=numpy.abs(rss._wave-skylines[i])>=dwave/2
+        weights=rss._data.copy()
+        weights[mask]=0
+        offsets[i,:]=numpy.nansum(rss._wave*weights, axis=1)/numpy.nansum(weights, axis=1)-skylines[i]
+        specoffset[i,0]=numpy.nanmedian(offsets[i,sel1])
+        specoffset[i,1]=numpy.nanmedian(offsets[i,sel2])
+        specoffset[i,2]=numpy.nanmedian(offsets[i,sel3])
+
+    #Average offsets for different skylines in each channel, apply to trace, and write them in header
+    meanoffset=numpy.nanmean(specoffset, axis=0)
+    print('Applying the following offsets [Angstroms] in [b,r,z] channels:', meanoffset)
+    rss._wave_trace['COEFF'].data[sel1,0] -= meanoffset[0]
+    rss._wave_trace['COEFF'].data[sel2,0] -= meanoffset[1]
+    rss._wave_trace['COEFF'].data[sel3,0] -= meanoffset[2]
+    rss._header[f'SKYOFF_{channel}1']=(f'{meanoffset[0]}', f'Mean sky line offset in {channel}1 [Angs]')
+    rss._header[f'SKYOFF_{channel}2']=(f'{meanoffset[1]}', f'Mean sky line offset in {channel}2 [Angs]')
+    rss._header[f'SKYOFF_{channel}3']=(f'{meanoffset[2]}', f'Mean sky line offset in {channel}3 [Angs]')
+
+    #write updated wobject
+    log.info(f"writing updated wobject file '{os.path.basename(out_rss)}'")
+    rss.writeFitsData(out_rss)
+
+    # Make QA plots showing offsets for each sky line in each channel
+    for i in range(len(skylines)):
+        fig, ax = plt.subplots() 
+        ax.plot(fiberid[sel1], offsets[i,sel1], label='Spec1', color='red', alpha=0.5)
+        ax.plot(fiberid[sel2], offsets[i,sel2], label='Spec2', color='green', alpha=0.5)   
+        ax.plot(fiberid[sel3], offsets[i,sel3], label='Spec3', color='blue', alpha=0.5)
+        ax.plot(fiberid[sel1], numpy.repeat(specoffset[i,0], len(fiberid[sel1])), linestyle='--', color='red')   
+        ax.plot(fiberid[sel2], numpy.repeat(specoffset[i,1], len(fiberid[sel2])), linestyle='--', color='green')   
+        ax.plot(fiberid[sel3], numpy.repeat(specoffset[i,2], len(fiberid[sel3])), linestyle='--', color='blue')   
+        ax.plot(fiberid[sel1], numpy.repeat(meanoffset[0], len(fiberid[sel1])), linestyle='-', color='red')   
+        ax.plot(fiberid[sel2], numpy.repeat(meanoffset[1], len(fiberid[sel2])), linestyle='-', color='green')   
+        ax.plot(fiberid[sel3], numpy.repeat(meanoffset[2], len(fiberid[sel3])), linestyle='-', color='blue')   
+        ax.hlines(0, 0, 1944, linestyle='--', color='black', alpha=0.3)   
+        ax.hlines(+0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)   
+        ax.hlines(-0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)   
+        ax.legend()
+        ax.set_ylim(-0.4,0.4)
+        ax.set_title(f'{rss._header['EXPOSURE']} - {channel} - {skylines[i]}')
+        ax.set_xlabel('Fiber ID')
+        ax.set_ylabel(r'$\Delta \lambda [\AA]$')
+    
+        save_fig(
+        fig,
+        product_path=out_rss,
+        to_display=False,
+        figure_path="qa",
+        label=f"skylineshift_{skylines[i]}")
+    
+   
+
+    #mask[sel]=0
+    #hdu1=fits.PrimaryHDU(rss._data)
+    #hdu2=fits.ImageHDU(rss._wave)
+    #hdu3=fits.ImageHDU(mask)
+    #hdul=fits.HDUList([hdu1, hdu2, hdu3])
+    #hdul.writeto(f'junk_{channel}.fits', overwrite=True)
+    
+
 # TODO:
 # * merge arc_wave and arc_lsfs into lvmArc product, change variable name to in_arc
 # @skip_on_missing_input_path(["in_rss", "in_waves", "in_lsfs"])

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -817,15 +817,7 @@ def shift_wave_skylines(in_rss: str, out_rss: str, channel: str):
         figure_path="qa",
         label=f"skylineshift_{skylines[i]}")
     
-   
 
-    #mask[sel]=0
-    #hdu1=fits.PrimaryHDU(rss._data)
-    #hdu2=fits.ImageHDU(rss._wave)
-    #hdu3=fits.ImageHDU(mask)
-    #hdul=fits.HDUList([hdu1, hdu2, hdu3])
-    #hdul.writeto(f'junk_{channel}.fits', overwrite=True)
-    
 
 # TODO:
 # * merge arc_wave and arc_lsfs into lvmArc product, change variable name to in_arc

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -806,7 +806,7 @@ def shift_wave_skylines(in_rss: str, out_rss: str, channel: str):
         ax.hlines(-0.05, 0, 1944, linestyle=':', color='black', alpha=0.3)   
         ax.legend()
         ax.set_ylim(-0.4,0.4)
-        ax.set_title(f'{rss._header['EXPOSURE']} - {channel} - {skylines[i]}')
+        ax.set_title(f'{rss._header["EXPOSURE"]} - {channel} - {skylines[i]}')
         ax.set_xlabel('Fiber ID')
         ax.set_ylabel(r'$\Delta \lambda [\AA]$')
     

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -191,6 +191,7 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
         rss_tasks.stack_spectrographs(in_rsss=xsci_paths, out_rss=xsci_path)
 
         # wavelength calibrate
+        # GB will add shifts based on sky lines for science frames
         rss_tasks.create_pixel_table(in_rss=xsci_path, out_rss=wsci_path, in_waves=mwave_paths, in_lsfs=mlsf_paths)
 
         # apply fiberflat correction

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -187,43 +187,43 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
         hsci_path = path.full('lvm_anc', mjd=sci_mjd, tileid=sci_tileid, drpver=drpver,
                               kind='h', camera=channel, imagetype=sci_imagetyp, expnum=expnum)
 
-#        # stack spectrographs
-#        rss_tasks.stack_spectrographs(in_rsss=xsci_paths, out_rss=xsci_path)
-#
+        # stack spectrographs
+        rss_tasks.stack_spectrographs(in_rsss=xsci_paths, out_rss=xsci_path)
+
         # wavelength calibrate
         rss_tasks.create_pixel_table(in_rss=xsci_path, out_rss=wsci_path, in_waves=mwave_paths, in_lsfs=mlsf_paths)
 
         # correct thermal shift in wavelength direction
         rss_tasks.shift_wave_skylines(in_rss=wsci_path, out_rss=wsci_path, channel=channel)
-#
-#        # apply fiberflat correction
-#        rss_tasks.apply_fiberflat(in_rss=wsci_path, out_frame=frame_path, in_flats=mflat_paths)
-#
-#        # interpolate sky fibers
-#        sky_tasks.interpolate_sky(in_frame=frame_path, out_rss=ssci_path)
-#
-#        # combine sky telescopes
-#        sky_tasks.combine_skies(in_rss=ssci_path, out_rss=ssci_path, sky_weights=sky_weights)
-#
-#        # resample wavelength into uniform grid along fiber IDs for science and sky fibers
-#        rss_tasks.resample_wavelength(in_rss=ssci_path,  out_rss=hsci_path, wave_range=SPEC_CHANNELS[channel], wave_disp=0.5, convert_to_density=True)
-#
-#        # use sky subtracted resampled frames for flux calibration in each camera
-#        flux_tasks.fluxcal_Gaia(channel, hsci_path, GAIA_CACHE_DIR=ORIG_MASTER_DIR+'/gaia_cache')
-#
-#        # flux-calibrate each channel
-#        fframe_path = path.full("lvm_frame", mjd=sci_mjd, drpver=drpver, tileid=sci_tileid, expnum=sci_expnum, kind=f'FFrame-{channel}')
-#        flux_tasks.apply_fluxcal(in_rss=hsci_path, out_rss=fframe_path, skip_fluxcal=skip_flux_calibration)
-#
-#    # stitch channels
-#    fframe_paths = sorted(path.expand('lvm_frame', mjd=sci_mjd, tileid=sci_tileid, drpver=drpver, kind='FFrame-?', expnum=expnum))
-#    cframe_path = path.full("lvm_frame", drpver=drpver, tileid=sci_tileid, mjd=sci_mjd, expnum=sci_expnum, kind='CFrame')
-#    rss_tasks.join_spec_channels(in_rsss=fframe_paths, out_rss=cframe_path, use_weights=True)
-#
-#    # sky subtraction
-#    sframe_path = path.full("lvm_frame", mjd=sci_mjd, drpver=drpver, tileid=sci_tileid, expnum=sci_expnum, kind='SFrame')
-#    sky_tasks.quick_sky_subtraction(in_cframe=cframe_path, out_sframe=sframe_path, skip_subtraction=skip_sky_subtraction)
-#
-#    # TODO: add quick report routine
-#
-#    # TODO: by default remove the extra files for the given expnum
+
+        # apply fiberflat correction
+        rss_tasks.apply_fiberflat(in_rss=wsci_path, out_frame=frame_path, in_flats=mflat_paths)
+
+        # interpolate sky fibers
+        sky_tasks.interpolate_sky(in_frame=frame_path, out_rss=ssci_path)
+
+        # combine sky telescopes
+        sky_tasks.combine_skies(in_rss=ssci_path, out_rss=ssci_path, sky_weights=sky_weights)
+
+        # resample wavelength into uniform grid along fiber IDs for science and sky fibers
+        rss_tasks.resample_wavelength(in_rss=ssci_path,  out_rss=hsci_path, wave_range=SPEC_CHANNELS[channel], wave_disp=0.5, convert_to_density=True)
+
+        # use sky subtracted resampled frames for flux calibration in each camera
+        flux_tasks.fluxcal_Gaia(channel, hsci_path, GAIA_CACHE_DIR=ORIG_MASTER_DIR+'/gaia_cache')
+
+        # flux-calibrate each channel
+        fframe_path = path.full("lvm_frame", mjd=sci_mjd, drpver=drpver, tileid=sci_tileid, expnum=sci_expnum, kind=f'FFrame-{channel}')
+        flux_tasks.apply_fluxcal(in_rss=hsci_path, out_rss=fframe_path, skip_fluxcal=skip_flux_calibration)
+
+    # stitch channels
+    fframe_paths = sorted(path.expand('lvm_frame', mjd=sci_mjd, tileid=sci_tileid, drpver=drpver, kind='FFrame-?', expnum=expnum))
+    cframe_path = path.full("lvm_frame", drpver=drpver, tileid=sci_tileid, mjd=sci_mjd, expnum=sci_expnum, kind='CFrame')
+    rss_tasks.join_spec_channels(in_rsss=fframe_paths, out_rss=cframe_path, use_weights=True)
+
+    # sky subtraction
+    sframe_path = path.full("lvm_frame", mjd=sci_mjd, drpver=drpver, tileid=sci_tileid, expnum=sci_expnum, kind='SFrame')
+    sky_tasks.quick_sky_subtraction(in_cframe=cframe_path, out_sframe=sframe_path, skip_subtraction=skip_sky_subtraction)
+
+    # TODO: add quick report routine
+
+    # TODO: by default remove the extra files for the given expnum

--- a/python/lvmdrp/functions/run_quickdrp.py
+++ b/python/lvmdrp/functions/run_quickdrp.py
@@ -148,25 +148,25 @@ def quick_science_reduction(expnum: int, use_fiducial_master: bool = False,
 
         log.info(f'--- Starting science reduction of raw frame: {rsci_path}')
 
-#        # preprocess frame
-#        image_tasks.preproc_raw_frame(in_image=rsci_path, out_image=psci_path, in_mask=mpixmask_path)
-#
-#        # detrend frame
-#        image_tasks.detrend_frame(in_image=psci_path, out_image=dsci_path,
-#                                  in_bias=mbias_path, in_dark=mdark_path, in_pixelflat=mpixflat_path,
-#                                  in_slitmap=Table(drp.fibermap.data), reject_cr=False)
-#
-#        # subtract straylight
-#        if sci_imagetyp == "flat":
-#            image_tasks.subtract_straylight(in_image=dsci_path, out_image=lsci_path,
-#                                                in_cent_trace=mtrace_path, select_nrows=5,
-#                                                aperture=13, smoothing=400, median_box=21, gaussian_sigma=0.0)
-#        else:
-#            lsci_path = dsci_path
-#
-#        # extract 1d spectra
-#        image_tasks.extract_spectra(in_image=dsci_path, out_rss=xsci_path, in_trace=mtrace_path, in_fwhm=mwidth_path,
-#                                    method=extraction_method, parallel=extraction_parallel)
+        # preprocess frame
+        image_tasks.preproc_raw_frame(in_image=rsci_path, out_image=psci_path, in_mask=mpixmask_path)
+
+        # detrend frame
+        image_tasks.detrend_frame(in_image=psci_path, out_image=dsci_path,
+                                  in_bias=mbias_path, in_dark=mdark_path, in_pixelflat=mpixflat_path,
+                                  in_slitmap=Table(drp.fibermap.data), reject_cr=False)
+
+        # subtract straylight
+        if sci_imagetyp == "flat":
+            image_tasks.subtract_straylight(in_image=dsci_path, out_image=lsci_path,
+                                                in_cent_trace=mtrace_path, select_nrows=5,
+                                                aperture=13, smoothing=400, median_box=21, gaussian_sigma=0.0)
+        else:
+            lsci_path = dsci_path
+
+        # extract 1d spectra
+        image_tasks.extract_spectra(in_image=dsci_path, out_rss=xsci_path, in_trace=mtrace_path, in_fwhm=mwidth_path,
+                                    method=extraction_method, parallel=extraction_parallel)
 
     # per channel reduction
     for channel in "brz":


### PR DESCRIPTION
Created "shift_wave_skylines" method in rssMethod.py which is now used after "create_pixel_table" in "quick_science_reduction". The method calculates the mean wavelength offset for a few skylines in each camera and applies it to the zeroth order coefficient in the wave_trace extension of the wobject file. It also writes diagnostic plots labeled "skylineshift" in the "ancillary/qa" directory.

Please propagate all 9 offsets (3 channels x 3 spectrographs) to the CFrame header