### PR TITLE
Adds new cli to download master calibs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,15 @@ To properly install and run the DRP you'll need to follow these steps first:
     wget -X css --reject html -nH -nc -t0 -r –level=2 -E –ignore-length -x -k -p -erobots=off -np -N https://data.sdss5.org/sas/sdsswork/data/lvm/lco/<mjd>/ --user <user> --password <password>
     ```
     **NOTE: we strongly recommend that you use the [SDSS access](https://github.com/sdss/sdss_access) product to achieve the same results.**
-    
-3. Download the current set of calibrations from the [SAS sandbox](https://data.sdss5.org/sas/sdsswork/lvm/sandbox/calib/) and add to your `.bashrc` (or equivalent) the following definition:
 
-    ```bash
-    export LVM_MASTER_DIR="path/to/master-calibrations"
-    ```
+3. Create a new python environment. This is optional, but strongly recommended. With conda this is done like this:
 
-    where `master-calibrations` contains only MJD folders.
-
-4. Create a new python environment. This is optional, but strongly recommended. With conda this is done like this:
-   
     ```bash
     conda create -n lvmdrp python=3.8
     ```
 
-5. Make sure you are in the intended python environment and directory:
-    
+4. Make sure you are in the intended python environment and directory:
+
     ```bash
     conda activate lvmdrp
     ```
@@ -60,20 +52,20 @@ If you are planning on installing the DRP on a system other than Ubuntu (e.g., M
 To install the DRP along with its dependencies, you need to run the following steps:
 
 1. Clone the Github repository:
-    
+
     ```bash
     git clone git@github.com:sdss/lvmdrp.git
     ```
 
 2. Go into the `lvmdrp` directory:
-    
+
     ```bash
     cd lvmdrp
     ```
 
 
 3. Install the DRP package in the current python environment (see [contributing](#contributing-to-lvm-drp-development) section below for a replacement of this step):
-    
+
     ```bash
     pip install .
     ```
@@ -87,6 +79,20 @@ envcheck
 ```
 
 if the variables are correctly set, you should see the values of each and a successful message.
+
+## Setup Calibration Files
+
+Download the current set of calibrations from the [SAS sandbox](https://data.sdss5.org/sas/sdsswork/lvm/sandbox/calib/).  After installation of the pipeline, you can use the command `drp get-calibs`.  For usage, run `drp get-calibs --help`. For
+example, to download all the calibration files for 60255, run
+
+```bash
+drp get-calibs -m 60255
+```
+
+This command will download the files using `sdss-access` and place them in `$LVM_MASTER_DIR`, which is defined by the
+pipeline as `$LVM_SANDBOX/calib`, mirroring the SAS.  These are defined automatically relative to your root `$SAS_BASE_DIR`.
+You would find the files at `$SAS_BASE_DIR/sdsswork/lvm/sandbox/calib/`
+
 
 ## Running the DRP
 

--- a/bin/drp
+++ b/bin/drp
@@ -18,6 +18,8 @@ from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
 from lvmdrp.functions.run_quickdrp import quick_science_reduction
 from lvmdrp.functions.run_twilights import reduce_twilight_sequence, MASK_BANDS
 
+from sdss_access import Access
+
 
 class IntRangeType(click.ParamType):
     name = 'int_list'
@@ -223,6 +225,31 @@ def erase(drpver: str):
         click.echo(f'Path {path} does not exist.')
         return
     shutil.rmtree(path)
+
+
+@cli.command(short_help='Download the master calibrations')
+@click.option('-k', '--kind', type=str, default='*', help='the kind of files to download, e.g "pixmask".', show_default=True)
+@click.option('-m', '--mjd', type=str, default='*', help='the MJD folder to download', show_default=True)
+@click.option('-c', '--camera', type=str, default='*', help='the camera to download, e.g. "b*" or "b1".', show_default=True)
+def get_calibs(kind, mjd, camera):
+    """ Download the master calibration frames
+
+    Downloads the master calibration frames from the Utah SAS in LVM_SANDBOX/calib.  This command
+    only downloads files when they do not yet exist on your local system.  To re-download existing
+    files, first delete your local files.
+
+    The syntax for the calibration files are $LVM_SANDBOX/calib/[mjd]/lvm-m[kind]-[camera].fits.
+    "mjd" is the MJD directory to download. "kind" is the kind of calib file to download, e.g. pixmask,
+    bias, fiberflat, without the leading "m".  "camera" is the camera can be a specific, e.g "b1" or
+    all channels with "b*".
+
+    """
+    a = Access()
+    a.remote()
+    a.add('lvm_calib', kind=kind, mjd=mjd, camera=camera)
+    a.set_stream()
+    a.commit()
+
 
 
 if __name__ == "__main__":

--- a/bin/drp
+++ b/bin/drp
@@ -240,8 +240,8 @@ def get_calibs(kind, mjd, camera):
 
     The syntax for the calibration files are $LVM_SANDBOX/calib/[mjd]/lvm-m[kind]-[camera].fits.
     "mjd" is the MJD directory to download. "kind" is the kind of calib file to download, e.g. pixmask,
-    bias, fiberflat, without the leading "m".  "camera" is the camera can be a specific, e.g "b1" or
-    all channels with "b*".
+    bias, fiberflat, without the leading "m".  "camera" is the camera, can be a specific channel, e.g "b1"
+    or all channels with "b*".
 
     """
     a = Access()

--- a/bin/drp
+++ b/bin/drp
@@ -235,8 +235,8 @@ def get_calibs(kind, mjd, camera):
     """ Download the master calibration frames
 
     Downloads the master calibration frames from the Utah SAS in LVM_SANDBOX/calib.  This command
-    only downloads files when they do not yet exist on your local system.  To re-download existing
-    files, first delete your local files.
+    only downloads files when they do not yet exist on your local system or when the remote files
+    are newer.
 
     The syntax for the calibration files are $LVM_SANDBOX/calib/[mjd]/lvm-m[kind]-[camera].fits.
     "mjd" is the MJD directory to download. "kind" is the kind of calib file to download, e.g. pixmask,


### PR DESCRIPTION
This PR adds a new cli, `drp get-calibs --help` to use `sdss-access` to download the master calibration frames from the Utah SAS.   Example usage to download all calib frames from 60255: `drp get-calibs -m 60255`.  This uses `sdss-access` to download the files, which puts them in the `$LVM_SANBOX/calib` relative to your `SAS_BASE_DIR`, e.g. `$SAS_BASE_DIR/sdsswork/lvm/sandbox/calib/`.  This mirrors the Utah SAS.  

```
Usage: drp get-calibs [OPTIONS]

  Download the master calibration frames

  Downloads the master calibration frames from the Utah SAS in
  LVM_SANDBOX/calib.  This command only downloads files when they do not yet
  exist on your local system.  To re-download existing files, first delete
  your local files.

  The syntax for the calibration files are
  $LVM_SANDBOX/calib/[mjd]/lvm-m[kind]-[camera].fits. "mjd" is the MJD
  directory to download. "kind" is the kind of calib file to download, e.g.
  pixmask, bias, fiberflat, without the leading "m".  "camera" is the camera
  can be a specific, e.g "b1" or all channels with "b*".

Options:
  -k, --kind TEXT    the kind of files to download, e.g "pixmask".  [default:
                     *]
  -m, --mjd TEXT     the MJD folder to download  [default: *]
  -c, --camera TEXT  the camera to download, e.g. "b*" or "b1".  [default: *]
  --help             Show this message and exit.
```