### PR TITLE
Fix tracing algorithm

### DIFF
--- a/python/lvmdrp/core/fit_profile.py
+++ b/python/lvmdrp/core/fit_profile.py
@@ -66,6 +66,7 @@ class fit_profile1D(object):
         y,
         sigma=1.0,
         p0=None,
+        bounds=(-numpy.inf, numpy.inf),
         ftol=1e-8,
         xtol=1e-8,
         maxfev=9999,
@@ -79,16 +80,11 @@ class fit_profile1D(object):
         perr_init = deepcopy(self)
         p0 = self._par
         if method == "leastsq":
-            try:
-                model = optimize.leastsq(
-                    self.res, p0, (x, y, sigma), maxfev=maxfev, ftol=ftol, xtol=xtol
-                )
-                # model = optimize.leastsq(self.res, p0, (x, y, sigma), None, 0, 0, ftol, xtol, 0.0, maxfev, 0.0, 100.0, None, warning)
-            except TypeError:
-                model = optimize.leastsq(
-                    self.res, p0, (x, y, sigma), maxfev=maxfev, ftol=ftol, xtol=xtol
-                )
-            self._par = model[0]
+            model = optimize.least_squares(
+                self.res, x0=p0, bounds=bounds, args=(x, y, sigma), max_nfev=maxfev, ftol=ftol, xtol=xtol,
+            )
+            self._par = model.x
+            # model = optimize.leastsq(self.res, p0, (x, y, sigma), None, 0, 0, ftol, xtol, 0.0, maxfev, 0.0, 100.0, None, warning)
 
         if method == "simplex":
             try:

--- a/python/lvmdrp/core/fit_profile.py
+++ b/python/lvmdrp/core/fit_profile.py
@@ -75,6 +75,8 @@ class fit_profile1D(object):
         method="leastsq",
         parallel="auto",
     ):
+        if not numpy.isfinite(sigma).all():
+            raise ValueError(f"Errors have non-finite values: {sigma}")
         if p0 is None and p0 is not False and self._guess_par is not None:
             self._guess_par(x, y)
         perr_init = deepcopy(self)

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -1914,7 +1914,7 @@ class Image(Header):
         pixels = numpy.arange(self._dim[0])
         models = []
         for i in range(self._dim[1]):
-            good_pix = ~self._mask[:,i] if self._mask is not None else numpy.isnan(self._data[:,i])
+            good_pix = ~self._mask[:,i] if self._mask is not None else ~numpy.isnan(self._data[:,i])
 
             # skip column if all pixels are masked
             if good_pix.sum() == 0:

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -2734,9 +2734,7 @@ class Spectrum1D(Header):
 
         return pixels, wave, data
 
-    def measurePeaks(
-        self, init_pos, method="gauss", init_sigma=1.0, threshold=0, max_diff=0
-    ):
+    def measurePeaks(self, init_pos, method="gauss", init_sigma=1.0, threshold=0, max_diff=0, ftol=1e-3, xtol=1e-3):
         """
         Find the subpixel centre for the local maxima in a Spectrum.
 
@@ -2838,7 +2836,7 @@ class Spectrum1D(Header):
                     gauss.fit(
                         self._pixels[init_pos[j] - 1 : init_pos[j] + 2],
                         self._data[init_pos[j] - 1 : init_pos[j] + 2],
-                        warning=False,
+                        warning=False, ftol=ftol, xtol=xtol
                     )  # perform fitting
                     positions[j] = gauss.getPar()[1]
 
@@ -3107,7 +3105,7 @@ class Spectrum1D(Header):
                 med_pos[i] = 0.0
         return offsets, med_pos
 
-    def fitMultiGauss(self, centres, init_fwhm):
+    def fitMultiGauss(self, centres, init_fwhm, bounds=(-numpy.inf, numpy.inf), ftol=1e-3, xtol=1e-3):
         select = numpy.zeros(self._dim, dtype="bool")
         flux_in = numpy.zeros(len(centres), dtype=numpy.float32)
         sig_in = numpy.ones_like(flux_in) * init_fwhm / 2.354
@@ -3126,7 +3124,7 @@ class Spectrum1D(Header):
             cent[i] = centres[i]
         par = numpy.concatenate([flux_in, cent, sig_in])
         gauss_multi = fit_profile.Gaussians(par)
-        gauss_multi.fit(self._wave[select], self._data[select], sigma=error[select])
+        gauss_multi.fit(self._wave[select], self._data[select], sigma=error[select], bounds=bounds, ftol=ftol, xtol=xtol)
         return gauss_multi, gauss_multi.getPar()
 
     def fitMultiGauss_fixed_cent(self, centres, init_fwhm):

--- a/python/lvmdrp/functions/imageMethod.py
+++ b/python/lvmdrp/functions/imageMethod.py
@@ -4894,8 +4894,9 @@ def trace_fibers(
     median_box = tuple(map(lambda x: max(x, 1), median_box))
     if median_box != (1, 1):
         log.info(f"performing median filtering with box {median_box} pixels")
-        img = img.replaceMaskMedian(*median_box)
-        img = img.medianImg(median_box)
+        img = img.replaceMaskMedian(*median_box, replace_error=None)
+        img._data = numpy.nan_to_num(img._data)
+        img = img.medianImg(median_box, propagate_error=True)
 
     # coadd images along the dispersion axis to increase the S/N of the peaks
     if coadd != 0:

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -710,7 +710,8 @@ def create_traces(mjds, target_mjd=None, expnums_ldls=None, expnums_qrtz=None,
                 # trace only centroids
                 centroids, img = image_tasks.trace_fibers(
                     in_image=dflat_path,
-                    out_trace_cent=cent_guess_path,
+                    out_trace_cent=None,
+                    out_trace_cent_guess=cent_guess_path,
                     correct_ref=True, median_box=(1,10), coadd=20,
                     counts_threshold=counts_threshold, max_diff=1.5,
                     guess_fwhm=2.5, method="gauss", ncolumns=140,

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -699,6 +699,7 @@ def create_traces(mjds, target_mjd=None, expnums_ldls=None, expnums_qrtz=None,
             lflat_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="l", imagetype="flat", camera=camera, expnum=expnum)
             flux_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="d", imagetype="flux", camera=camera, expnum=expnum)
             cent_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="d", imagetype="cent", camera=camera, expnum=expnum)
+            cent_guess_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="d", imagetype="cent_guess", camera=camera, expnum=expnum)
             fwhm_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="d", imagetype="fwhm", camera=camera, expnum=expnum)
             model_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="d", imagetype="model", camera=camera, expnum=expnum)
             mratio_path = path.full("lvm_anc", drpver=drpver, tileid=tileid, mjd=masters_mjd, kind="d", imagetype="mratio", camera=camera, expnum=expnum)
@@ -709,7 +710,7 @@ def create_traces(mjds, target_mjd=None, expnums_ldls=None, expnums_qrtz=None,
                 # trace only centroids
                 centroids, img = image_tasks.trace_fibers(
                     in_image=dflat_path,
-                    out_trace_cent=cent_path,
+                    out_trace_cent=cent_guess_path,
                     correct_ref=True, median_box=(1,10), coadd=20,
                     counts_threshold=counts_threshold, max_diff=1.5,
                     guess_fwhm=2.5, method="gauss", ncolumns=140,
@@ -721,7 +722,7 @@ def create_traces(mjds, target_mjd=None, expnums_ldls=None, expnums_qrtz=None,
                 image_tasks.subtract_straylight(
                     in_image=dflat_path,
                     out_image=lflat_path,
-                    in_cent_trace=cent_path,
+                    in_cent_trace=cent_guess_path,
                     out_stray=mstray_path,
                     select_nrows=5,
                     median_box=21, aperture=13, smoothing=400, gaussian_sigma=0.0
@@ -733,11 +734,11 @@ def create_traces(mjds, target_mjd=None, expnums_ldls=None, expnums_qrtz=None,
             centroids, trace_cent_fit, trace_flux_fit, trace_fwhm_fit, img_stray, model, mratio = image_tasks.trace_fibers(
                 in_image=lflat_path,
                 out_trace_amp=flux_path, out_trace_cent=cent_path, out_trace_fwhm=fwhm_path,
-                out_trace_cent_guess=None,
+                out_trace_cent_guess=cent_guess_path,
                 correct_ref=True, median_box=(1,10), coadd=20,
                 counts_threshold=counts_threshold, max_diff=1.5, guess_fwhm=2.5, method="gauss",
                 ncolumns=(140, 40), iblocks=block_idxs, fwhm_limits=(1.5, 4.5),
-                fit_poly=fit_poly, interpolate_missing=False, poly_deg=(poly_deg_amp, poly_deg_cent, poly_deg_width)
+                fit_poly=fit_poly, interpolate_missing=False, poly_deg=(poly_deg_amp, poly_deg_cent, poly_deg_width), use_given_centroids=True
             )
 
             # update master traces


### PR DESCRIPTION
Fixes the tracing algorithm for instabilities when applying constraints in fiber positions, amplitudes and widths. Now the fitting implements built-in constraints using the `least_sqrt` `bounds` parameter.

Also fixes bug in error propagation when interpolating masked pixels during tracing and overall improved handling of guess centroids.