### PR TITLE
Fixes issues with parallel drpall generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ This document records the main changes to the drp code.
 1.0.4 (unreleased)
 ------------------
 
+- Adds a lockfile to drpall write, with 5 sec timeout, to prevent collisions during parallel writes.
 
 1.0.3 (29-05-2024)
 ------------------

--- a/python/lvmdrp/utils/metadata.py
+++ b/python/lvmdrp/utils/metadata.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 from astropy.io import fits
 from astropy.table import Table
+from filelock import FileLock, Timeout
 from tqdm import tqdm
 
 from lvmdrp.core.constants import FRAMES_CALIB_NEEDS
@@ -1473,6 +1474,7 @@ def update_summary_file(filename: str, tileid: int = None, mjd: int = None, expn
     # get the row(s) from the raw frames metadata
     df = get_metadata(tileid=int(tileid), mjd=int(mjd), expnum=int(expnum), imagetyp='object')
     if df is None or df.empty:
+        log.info(f'No metadata found for {tileid=}, {mjd=}, {expnum=}. Exiting.')
         return
 
     # select unique expnum row, i.e. remove duplicates from camera/spec rows
@@ -1508,13 +1510,19 @@ def update_summary_file(filename: str, tileid: int = None, mjd: int = None, expn
     # create drpall h5 filepath
     drpall = path.full('lvm_drpall', drpver=DRPVER)
     drpall = drpall.replace('.fits', '.h5')
+    lock = FileLock(drpall.replace('.h5', '.h5.lock'), timeout=5)
 
     # write to pytables hdf5
     try:
-        df.to_hdf(drpall, key='summary', append=True, data_columns=True, min_itemsize={'skye_name': 20, 'skyw_name': 20, 'location': 120, 'agcam_location': 120})
+        with lock:
+            df.to_hdf(drpall, key='summary', mode='a', append=True, data_columns=True, min_itemsize={'skye_name': 20, 'skyw_name': 20, 'location': 120, 'agcam_location': 120})
     except ImportError:
         log.error('Missing pytables dependency. Install with `pip install "pandas[hdf5]"`. '
                       'On macs, you may first need to first run "brew install hdf5".')
+    except Timeout:
+        log.error("Another instance of the drp currently holds the drpall lock.")
+    else:
+        log.info(f'Updating drpall file {drpall}.')
 
 
 def convert_h5_to_fits(h5file: str):

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
 	cloup>=2.0
 	bottleneck>=1.3.7
 	h5py>=3.8.0
+	filelock>=3.14.0
 	numexpr==2.8.4
 	gaiaxpy>=2.1.0
 	# TODO: add lvmscheduler dependency from the repository


### PR DESCRIPTION
This PR closes #94 with an issue when the drpall summary rows were being written by multiple processes at the same time.  This PR uses the `lockfile` package to set up a lock on the drpall hdf5 file, during write, with a retry-timeout of 5 seconds.

This should now allow for safe updates/appends of the drpall file during cluster runs.  At the end of the cluster run, we can manually run the `convert_h5_to_fits` to also produce a FITS file version of the summary file, which can be easier for astronomers to use. 
   