### PR TITLE
fixes skytable mjd bug

### DIFF
--- a/python/lvmdrp/functions/skyMethod.py
+++ b/python/lvmdrp/functions/skyMethod.py
@@ -1645,7 +1645,7 @@ def quick_sky_subtraction(in_cframe, out_sframe,
     sky_error[skywfibers] = skywsky_error
 
     # write out sky table to ancillary file
-    mjd = cframe._header['MJD']
+    mjd = cframe._header['SMJD']  # use SMJD to account for exposures taken before the nightly MJD switch
     expnum = cframe._header['EXPOSURE']
     tileid = cframe._header['TILE_ID']
     skytable = path.full('lvm_anc', mjd=mjd, tileid=tileid, drpver=drpver,


### PR DESCRIPTION
This PR fixes a bug when writing out the skytable ancillary file.   Some science exposures were taken during twilight or early in the night, before the MJD nightly switch.   I examined 4053 lvmCFrame files in `master`, and 137 have `MJD` != `SMJD` in the headers.   The culprit MJDs were sporadic from 60177 up to 60500 (the last MJD I checked), with no pattern, so I don't think it's a larger bug in the code.   For a few cases, I also checked that the `MJD` and `SMJD` values in the `lvmCFrame` files match the values in their respective raw frame `sdR` files.  

The output reduction paths and metadata are correct, but if we're pulling info from the headers, we need to use the `SMJD` header keyword for the correct value.  

