### PR TITLE
Refinement of fiber thermal fiber shifts

### DIFF
--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -705,7 +705,7 @@ class Image(Header):
     def __ge__(self, other):
         return self._data >= other
 
-    def measure_fiber_shifts(self, ref_image, columns=[500, 1000, 1500, 2000, 2500, 3000], column_width=25, shift_range=[-5,5]):
+    def measure_fiber_shifts(self, ref_image, columns=[500, 1000, 1500, 2000, 2500, 3000], column_width=25, shift_range=[-5,5], axs=None):
         '''Measure the (thermal, flexure, ...) shift between the fiber (traces) in 2 detrended images in the y (cross dispersion) direction.
 
         Uses cross-correlations between (medians of a number of) columns to determine
@@ -740,8 +740,7 @@ class Image(Header):
             snr = numpy.sqrt(numpy.nanmedian(self._data[50:-50,c-column_width:c+column_width], axis=1))
 
             if numpy.nanmedian(snr) > 5:
-                print(f"too low SNR to reliably measure thermal shift at column {c}: {numpy.nanmedian(snr):.4f}, assuming shift = 0.0")
-                _, shifts[j], _ = _cross_match_float(s1, s2, numpy.array([1.0]), shift_range)
+                _, shifts[j], _ = _cross_match_float(s1, s2, numpy.array([1.0]), shift_range, ax=axs[j])
             else:
                 log.warning(f"too low SNR to reliably measure thermal shift at column {c}: {numpy.nanmedian(snr):.4f}, assuming shift = 0.0")
                 shifts[j] = 0.0

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -12,6 +12,7 @@ from typing import List, Tuple
 from lvmdrp import log
 from lvmdrp.utils import gaussian
 from lvmdrp.core import fit_profile
+from lvmdrp.core import plot
 from lvmdrp.core.header import Header
 
 
@@ -236,6 +237,7 @@ def _cross_match_float(
     obs_spec: numpy.ndarray,
     stretch_factors: numpy.ndarray,
     shift_range: List[int],
+    ax: None|plot.plt.Axes = None
 ) -> Tuple[float, float, float]:
     """Find the best fractional-pixel cross correlation between two spectra.
 
@@ -304,32 +306,33 @@ def _cross_match_float(
             len(obs_spec_), len(stretched_signal1), mode="same"
         )
 
-        # Constrain the cross_corr and shifts to the shift_range
-        mask = (shifts >= -10) & (shifts <= +10)
-        cross_corr = cross_corr[mask]
-        shifts = shifts[mask]
-
-        #return cross_cor
-
         # Find the max correlation and the corresponding shift for this stretch factor
-        idx_max_corr = numpy.argmax(cross_corr)
-        max_corr = cross_corr[idx_max_corr]
-        shift = shifts[idx_max_corr]
+        mask = (shifts >= min_shift) & (shifts <= max_shift)
+        idx_max_corr = numpy.argmax(cross_corr[mask])
+        max_corr = cross_corr[mask][idx_max_corr]
+        shift = shifts[mask][idx_max_corr]
 
-        import matplotlib.pyplot as plt
-        plt.figure()
-        plt.step(shifts, cross_corr, where="mid")
-        plt.axvline(shift)
-        plt.show()
+        # Fit Gaussian around maximum cross-correlation peak
+        guess = [1.0, shift, 1.0, 0.0]
+        bound_lower = [0.0, shift+min_shift, 0.0, 0.0]
+        bound_upper = [numpy.inf, shift+max_shift, 5.0, numpy.inf]
+        gauss = fit_profile.Gaussian_const(guess)
+        mask = (shifts >= -3) & (shifts <= 3)
+        gauss.fit(
+            shifts[mask],
+            cross_corr[mask],
+            sigma=1.0,
+            p0=guess,
+            bounds=(bound_lower, bound_upper)
+        )
+        area, position, sigma, bg = gauss.getPar()
 
-        plt.figure()
-        plt.plot(obs_spec_)
-        plt.plot(ref_spec_)
-        plt.show()
-
-        # poor man's parabola fit ...
-        d = (cross_corr[idx_max_corr + 1] - 2 * cross_corr[idx_max_corr] + cross_corr[idx_max_corr - 1])
-        position = (shift + 1 - ((cross_corr[idx_max_corr + 1] - cross_corr[idx_max_corr])) / d )
+        ax.step(shifts, cross_corr, color="0.2", lw=2, where="mid")
+        ax.step(shifts, gauss(shifts), color="tab:red", lw=1, where="mid")
+        ax.axvline(shift, color="tab:blue", lw=1, ls="--")
+        ax.axvline(position, color="tab:red", lw=1)
+        ax.text(shift, cross_corr[mask].min(), f"{shift}", va="bottom", ha="left", color="tab:blue")
+        ax.text(position, cross_corr[mask].min(), f"shift = {position:.3f}", va="bottom", ha="right", color="tab:red")
 
         condition = max_corr > max_correlation
 


### PR DESCRIPTION
After last update of fiber thermal shift measurements, some issues have been found:

- Noisy fiber profile, yielding unreliable cross-correlation with fiber model (see figure below)
- Unreliable shift sub-pixel measurement

![image](https://github.com/user-attachments/assets/e129dd20-303d-41e3-8106-15fcfa6befd3)

The first issue was fixed by setting a threshold on the initial fiber locations, whereby fibers cannot be closer than 5 pixels (consistent with fiber centroid measurements). The second issue was fixed by fitting a Gaussian + constant term around the maximum cross-correlation.

QA plots were also improved

![image](https://github.com/user-attachments/assets/a6b9392d-4036-4b74-a55d-8a1568c80fd2)
