### PR TITLE
Improving fiber flats

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Lint with ruff
       run: |
         pip install ruff
-        ruff check .
+        ruff check . --extend-exclude "examples/**" --extend-exclude "docs/nb/**"
 
     - name: Test with pytest
       run: |

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -1091,7 +1091,7 @@ class RSS(FiberRows):
                 continue
             new_specs.append(spec.flatten_lsf(target_fwhm, min_fwhm=min_fwhm))
 
-        return RSS.from_spectra1d(new_specs)
+        return RSS.from_spectra1d(new_specs, header=self._header)
 
     def maskFiber(self, fiber, replace_error=1e10):
         self._data[fiber, :] = 0

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -580,16 +580,16 @@ class RSS(FiberRows):
         if numpy.allclose(
             numpy.repeat(rss._wave[0][None, :], rss._fibers, axis=0), rss._wave
         ):
-            rss.setWave(rss._wave[0])
+            rss.set_wave_array(rss._wave[0])
         else:
-            rss.setWave(rss._wave)
+            rss.set_wave_array(rss._wave)
         if numpy.allclose(
             numpy.repeat(rss._lsf[0][None, :], rss._fibers, axis=0),
             rss._lsf,
         ):
-            rss.set_lsf(rss._lsf[0])
+            rss.set_lsf_array(rss._lsf[0])
         else:
-            rss.set_lsf(rss._lsf)
+            rss.set_lsf_array(rss._lsf)
         return rss
 
     def __init__(

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -1091,7 +1091,7 @@ class RSS(FiberRows):
                 continue
             new_specs.append(spec.flatten_lsf(target_fwhm, min_fwhm=min_fwhm))
 
-        return RSS.from_spectra1d(new_specs, header=self._header)
+        return RSS.from_spectra1d(new_specs, header=self._header, slitmap=self._slitmap, good_fibers=self._good_fibers)
 
     def maskFiber(self, fiber, replace_error=1e10):
         self._data[fiber, :] = 0

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -2426,8 +2426,9 @@ class Spectrum1D(Header):
 
         return new_spec
 
-    def interpolate_masked(self, inplace=False):
-        if self._mask is None or self._mask.all():
+    def interpolate_masked(self, mask=None, inplace=False):
+        mask = mask if mask is not None else self._mask
+        if mask is None or mask.all():
             return self
 
         if inplace:
@@ -2435,7 +2436,7 @@ class Spectrum1D(Header):
         else:
             new_spec = deepcopy(self)
 
-        good_pix = ~self._mask
+        good_pix = ~mask
         new_spec._data = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._data[good_pix], left=new_spec._data[good_pix][0], right=new_spec._data[good_pix][-1])
         if new_spec._error is not None:
             new_spec._error = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._error[good_pix], left=new_spec._error[good_pix][0], right=new_spec._error[good_pix][-1])

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -2427,13 +2427,13 @@ class Spectrum1D(Header):
             new_spec = deepcopy(self)
 
         good_pix = ~self._mask
-        new_spec._data = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._data[good_pix])
+        new_spec._data = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._data[good_pix], left=new_spec._data[good_pix][0], right=new_spec._data[good_pix][-1])
         if new_spec._error is not None:
-            new_spec._error = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._error[good_pix])
+            new_spec._error = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._error[good_pix], left=new_spec._error[good_pix][0], right=new_spec._error[good_pix][-1])
         if new_spec._sky is not None:
-            new_spec._sky = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._sky[good_pix])
+            new_spec._sky = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._sky[good_pix], left=new_spec._sky[good_pix][0], right=new_spec._sky[good_pix][-1])
         if new_spec._sky_error is not None:
-            new_spec._sky_error = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._sky_error[good_pix])
+            new_spec._sky_error = numpy.interp(new_spec._wave, new_spec._wave[good_pix], new_spec._sky_error[good_pix], left=new_spec._sky_error[good_pix][0], right=new_spec._sky_error[good_pix][-1])
 
         return new_spec
 

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -2479,22 +2479,23 @@ class Spectrum1D(Header):
         else:
             new_spec = deepcopy(self)
 
+        # interpolate masked pixels
         if interpolate_bad:
             new_spec = new_spec.interpolate_masked(inplace=inplace)
 
-        data = self._data
-        wave = self._wave
-        fwhm = self._lsf
-        if self._error is not None:
-            error = self._error
+        data = new_spec._data
+        wave = new_spec._wave
+        fwhm = new_spec._lsf
+        if new_spec._error is not None:
+            error = new_spec._error
         else:
             error = None
-        if self._sky is not None:
-            sky = self._sky
+        if new_spec._sky is not None:
+            sky = new_spec._sky
         else:
             sky = None
-        if self._sky_error is not None:
-            sky_error = self._sky_error
+        if new_spec._sky_error is not None:
+            sky_error = new_spec._sky_error
         else:
             sky_error = None
 

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -502,7 +502,7 @@ class Spectrum1D(Header):
         self._sky_error = sky_error
         self._header = header
 
-        self.set_wave_and_lsf_traces(wave=wave, wave_trace=wave_trace, lsf_trace=lsf_trace)
+        self.set_wave_and_lsf_traces(wave=wave, wave_trace=wave_trace, lsf_trace=lsf_trace, lsf=lsf)
 
     def __sub__(self, other):
         if isinstance(other, Spectrum1D):

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1136,7 +1136,7 @@ def resample_wavelength(in_rss: str, out_rss: str, method: str = "linear",
     return new_rss
 
 
-def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1):
+def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1, plot_fibers=[0, 900, 1943], display_plots=False):
     """
     Homogenise the LSF of the RSS to a common spectral resolution (FWHM)
 
@@ -1156,6 +1156,10 @@ def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1):
         Spectral resolution in FWHM Agnstroms to which the RSS will be homogenised, by default None
     min_fwhm : float, optional
         Minimum spectral resolution in FWHM allowed, by default 0.1 Angstrom
+    plot_fibers : list[int], optional
+        List of fiber indices to plot, by default [0, 900, 1943]
+    display_plots : bool, optional
+        Show plot on screen or not, by default False
 
     Returns
     -------
@@ -1168,6 +1172,14 @@ def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1):
     new_rss._lsf = None
     new_rss.setHdrValue("HIERARCH WAVE RES", target_fwhm, "FWHM of spectral resolution [Angstrom]")
     new_rss.writeFitsData(out_rss)
+
+    if plot_fibers:
+        fig, ax = create_subplots(to_display=display_plots, figsize=(15,7), layout="constrained")
+        for ifiber in plot_fibers:
+            ln, = ax.step(rss._wave, rss._data[ifiber], lw=1, where="mid", alpha=0.5)
+            ax.step(new_rss._wave, new_rss._data[ifiber], lw=1, where="mid", color=ln.get_color(), label=ifiber)
+        ax.legend(loc=1, frameon=False, title="Fiber Idx")
+        save_fig(fig, to_display=display_plots, product_path=out_rss, figure_path="qa", label="match_res")
 
     return new_rss
 

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1601,8 +1601,8 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str, clip_below: float
         # apply clipping
         select_clip_below = (spec_flat < clip_below) | numpy.isnan(spec_flat._data)
         spec_flat._data[select_clip_below] = 1
-        if spec_flat._mask is not None:
-            spec_flat._mask[select_clip_below] = True
+        # if spec_flat._mask is not None:
+        #     spec_flat._mask[select_clip_below] = True
 
         # correct
         spec_new = spec_data / spec_flat._data

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1179,8 +1179,9 @@ def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1, plot_fiber
         fig, ax = create_subplots(to_display=display_plots, figsize=(15,5), layout="constrained")
         fig.suptitle(f"Matched LSF for {camera = }, {expnum = }")
         for ifiber in plot_fibers:
-            ln, = ax.step(rss._wave, rss._data[ifiber], lw=1, where="mid", alpha=0.5)
-            ax.step(new_rss._wave, new_rss._data[ifiber], lw=1, where="mid", color=ln.get_color(), label=ifiber)
+            wave = rss._wave if len(rss._wave.shape) == 1 else rss._wave[ifiber]
+            ln, = ax.step(wave, rss._data[ifiber], lw=1, where="mid", alpha=0.5)
+            ax.step(wave, new_rss._data[ifiber], lw=1, where="mid", color=ln.get_color(), label=ifiber)
         ax.legend(loc=1, frameon=False, title="Fiber Idx", ncols=7)
         save_fig(fig, to_display=display_plots, product_path=out_rss, figure_path="qa", label="match_res")
 

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1166,7 +1166,7 @@ def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1):
 
     new_rss = rss.match_lsf(target_fwhm, min_fwhm=min_fwhm)
     new_rss._lsf = None
-    new_rss.setHdrValue("HIERARCH WAVE RES", target_fwhm, "FWHM of spectral resolution [Agnstrom]")
+    new_rss.setHdrValue("HIERARCH WAVE RES", target_fwhm, "FWHM of spectral resolution [Angstrom]")
     new_rss.writeFitsData(out_rss)
 
     return new_rss

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1167,18 +1167,21 @@ def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1, plot_fiber
         New RSS with homogenised LSF
     """
     rss = RSS.from_file(in_rss)
+    camera = rss._header["CCD"]
+    expnum = rss._header["EXPOSURE"]
 
     new_rss = rss.match_lsf(target_fwhm, min_fwhm=min_fwhm)
     new_rss._lsf = None
-    new_rss.setHdrValue("HIERARCH WAVE RES", target_fwhm, "FWHM of spectral resolution [Angstrom]")
+    new_rss.setHdrValue("HIERARCH WAVE RES", target_fwhm, "spectral resolution (FWHM) [Angstrom]")
     new_rss.writeFitsData(out_rss)
 
     if plot_fibers:
-        fig, ax = create_subplots(to_display=display_plots, figsize=(15,7), layout="constrained")
+        fig, ax = create_subplots(to_display=display_plots, figsize=(15,5), layout="constrained")
+        fig.suptitle(f"Matched LSF for {camera = }, {expnum = }")
         for ifiber in plot_fibers:
             ln, = ax.step(rss._wave, rss._data[ifiber], lw=1, where="mid", alpha=0.5)
             ax.step(new_rss._wave, new_rss._data[ifiber], lw=1, where="mid", color=ln.get_color(), label=ifiber)
-        ax.legend(loc=1, frameon=False, title="Fiber Idx")
+        ax.legend(loc=1, frameon=False, title="Fiber Idx", ncols=7)
         save_fig(fig, to_display=display_plots, product_path=out_rss, figure_path="qa", label="match_res")
 
     return new_rss

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1136,7 +1136,7 @@ def resample_wavelength(in_rss: str, out_rss: str, method: str = "linear",
     return new_rss
 
 
-def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1, plot_fibers=[0, 900, 1943], display_plots=False):
+def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1, plot_fibers=[0,300,600,900,1200,1400,1700], display_plots=False):
     """
     Homogenise the LSF of the RSS to a common spectral resolution (FWHM)
 
@@ -1157,7 +1157,7 @@ def match_resolution(in_rss, out_rss, target_fwhm=None, min_fwhm=0.1, plot_fiber
     min_fwhm : float, optional
         Minimum spectral resolution in FWHM allowed, by default 0.1 Angstrom
     plot_fibers : list[int], optional
-        List of fiber indices to plot, by default [0, 900, 1943]
+        List of fiber indices to plot, by default [0,300,600,900,1200,1400,1700]
     display_plots : bool, optional
         Show plot on screen or not, by default False
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1658,11 +1658,11 @@ def create_twilight_fiberflats(mjd: int, use_fiducial_cals: bool = True, expnums
             # calibrate in wavelength
             rss_tasks.create_pixel_table(in_rss=xflat_path, out_rss=wflat_path, in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
+            # match LSF in all fibers
+            rss_tasks.match_resolution(in_rss=wflat_path, out_rss=wflat_path, target_fwhm=4.5)
+
             # rectify in wavelength
             rss_tasks.resample_wavelength(in_rss=wflat_path, out_rss=hflat_path, wave_disp=0.5, wave_range=SPEC_CHANNELS[channel])
-
-            # match LSF in all fibers
-            rss_tasks.match_resolution(in_rss=hflat_path, out_rss=hflat_path, target_fwhm=3.0)
 
             # fit fiber throughput
             fit_fiberflat(in_twilight=hflat_path, out_flat=fflat_path, out_twilight=fflat_flatfielded_path, remove_gradient=True, niter=4, display_plots=display_plots)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -55,7 +55,7 @@ from lvmdrp.core.rss import RSS, lvmFrame
 from lvmdrp.functions import imageMethod as image_tasks
 from lvmdrp.functions import rssMethod as rss_tasks
 from lvmdrp.main import get_config_options, read_fibermap, get_master_mjd, reduce_2d
-from lvmdrp.functions.run_twilights import fit_fiberflat, combine_twilight_sequence
+from lvmdrp.functions.run_twilights import lvmFlat, fit_fiberflat, create_lvmflat, combine_twilight_sequence
 
 
 SLITMAP = read_fibermap(as_table=True)
@@ -1532,9 +1532,9 @@ def create_dome_fiberflats(mjd, expnums_ldls, expnums_qrtz, use_fiducial_cals=Tr
         fflat.writeFitsData(mflat_path)
         # create lvmFlat object
         lvmflat = lvmFlat(data=xflat._data / fflat._data, error=xflat._error, mask=xflat._mask, header=xflat._header,
-                              cent_trace=mcent, width_trace=mwidth,
-                              wave_trace=mwave, lsf_trace=mlsf,
-                              superflat=fflat._data, slitmap=SLITMAP)
+                          cent_trace=mcent, width_trace=mwidth,
+                          wave_trace=mwave, lsf_trace=mlsf,
+                          superflat=fflat._data, slitmap=SLITMAP)
         lvmflat.writeFitsData(path.full("lvm_frame", mjd=mjd, tileid=11111, drpver=drpver, expnum=expnum_str, kind=f'Flat-{channel}'))
 
 
@@ -1626,12 +1626,11 @@ def create_twilight_fiberflats(mjd: int, use_fiducial_cals: bool = True, expnums
 
     # decompose twilight spectra into sun continuum and twilight components
     channels = "brz"
-    mfflats = dict.fromkeys(channels)
     flat_channels = flats.groupby(flats.camera.str.__getitem__(0))
     tileid = flats.tileid.min()
     for channel in channels:
         flat_expnums = flat_channels.get_group(channel).groupby("expnum")
-        fflats = []
+        fflat_paths = []
         for expnum in flat_expnums.groups:
             flat = flat_expnums.get_group(expnum).iloc[0]
 
@@ -1639,19 +1638,19 @@ def create_twilight_fiberflats(mjd: int, use_fiducial_cals: bool = True, expnums
             fflat_flatfielded_path = path.full("lvm_anc", drpver=drpver, kind="flatfielded_",
                                    imagetype=flat.imagetyp, tileid=flat.tileid, mjd=flat.mjd,
                                    camera=channel, expnum=expnum)
-            fflat_path = path.full("lvm_anc", drpver=drpver, kind="f",
-                                   imagetype="flat", tileid=flat.tileid, mjd=flat.mjd, camera=channel, expnum=expnum)
+            fflat_path = path.full("lvm_anc", drpver=drpver, kind="f", imagetype="flat", tileid=flat.tileid, mjd=flat.mjd, camera=channel, expnum=expnum)
+            fflat_paths.append(fflat_path)
             xflat_path = path.full("lvm_anc", drpver=drpver, kind="x", imagetype=flat.imagetyp, tileid=flat.tileid, mjd=flat.mjd, camera=channel, expnum=expnum)
             wflat_path = path.full("lvm_anc", drpver=drpver, kind="w", imagetype=flat.imagetyp, tileid=flat.tileid, mjd=flat.mjd, camera=channel, expnum=expnum)
             hflat_path = path.full("lvm_anc", drpver=drpver, kind="h", imagetype=flat.imagetyp, tileid=flat.tileid, mjd=flat.mjd, camera=channel, expnum=expnum)
             # gflat_path = path.full("lvm_anc", drpver=drpver, kind="g", imagetype=flat.imagetyp, tileid=flat.tileid, mjd=flat.mjd, camera=channel, expnum=expnum)
+            lvmflat_path = path.full("lvm_frame", mjd=mjd, tileid=tileid, drpver=drpver, expnum=expnum, kind=f'Flat-{channel}')
 
             # spectrograph stack xflats
             rss_tasks.stack_spectrographs(in_rsss=xflat_paths, out_rss=xflat_path)
 
             # calibrate in wavelength
-            rss_tasks.create_pixel_table(in_rss=xflat_path, out_rss=wflat_path,
-                                         in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
+            rss_tasks.create_pixel_table(in_rss=xflat_path, out_rss=wflat_path, in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
             # rectify in wavelength
             rss_tasks.resample_wavelength(in_rss=wflat_path, out_rss=hflat_path, wave_disp=0.5, wave_range=SPEC_CHANNELS[channel])
@@ -1660,36 +1659,16 @@ def create_twilight_fiberflats(mjd: int, use_fiducial_cals: bool = True, expnums
             rss_tasks.match_resolution(in_rss=hflat_path, out_rss=hflat_path, target_fwhm=3.0)
 
             # fit fiber throughput
-            fflat = fit_fiberflat(in_twilight=hflat_path, out_flat=fflat_path, out_rss=fflat_flatfielded_path, remove_gradient=True, niter=4, display_plots=display_plots)
+            fit_fiberflat(in_twilight=hflat_path, out_flat=fflat_path, out_twilight=fflat_flatfielded_path, remove_gradient=True, niter=4, display_plots=display_plots)
 
-            # load fiber and wavelength traces
-            mcent = TraceMask.from_spectrographs(*[TraceMask.from_file(master_cent) for master_cent in calibs["trace"][channel]])
-            mwidth = TraceMask.from_spectrographs(*[TraceMask.from_file(master_width) for master_width in calibs["width"][channel]])
-            mwave = TraceMask.from_spectrographs(*[TraceMask.from_file(master_wave) for master_wave in calibs["wave"][channel]])
-            mlsf = TraceMask.from_spectrographs(*[TraceMask.from_file(master_lsf) for master_lsf in calibs["lsf"][channel]])
+            # create lvmFlat product
+            create_lvmflat(in_twilight=fflat_flatfielded_path, out_lvmflat=lvmflat_path, in_fiberflat=fflat_path,
+                           in_cents=calibs["trace"][channel], in_widths=calibs["width"][channel],
+                           in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
-            fflat.set_wave_trace(mwave)
-            fflat.set_lsf_trace(mlsf)
-            fflat = fflat.to_native_wave(method="linear", interp_density=False, return_density=False)
-            fflats.append(fflat)
-
-            # build lvmFlat
-            twilight = RSS.from_file(fflat_flatfielded_path)
-            twilight.set_wave_trace(mwave)
-            twilight.set_lsf_trace(mlsf)
-            twilight = twilight.to_native_wave(method="linear", interp_density=True, return_density=False)
-            lvmflat = lvmFlat(data=twilight._data, error=twilight._error, mask=twilight._mask, header=twilight._header,
-                              cent_trace=mcent, width_trace=mwidth,
-                              wave_trace=mwave, lsf_trace=mlsf,
-                              superflat=fflat._data, slitmap=twilight._slitmap)
-            lvmflat.writeFitsData(path.full("lvm_frame", mjd=mjd, tileid=tileid, drpver=drpver, expnum=expnum, kind=f'Flat-{channel}'))
-
-        mfflat = combine_twilight_sequence(fflats=fflats)
+        # combine individual fiberflats into master fiberflat
         mflat_path = path.full("lvm_master", drpver=drpver, tileid=tileid, mjd=mjd, kind="mfiberflat_twilight", camera=channel)
-        mfflat.writeFitsData(mflat_path, replace_masked=False)
-        mfflats[channel] = mfflat
-
-    return mfflats
+        combine_twilight_sequence(in_fiberflats=fflat_paths, out_fiberflat=mflat_path, in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
 
 def create_illumination_corrections(mjd, use_fiducial_cals=True, expnums=None):
@@ -2033,21 +2012,6 @@ def create_fiber_model(mjd, flux=10000):
         model.setHeader(trace_cent._header)
         model.setHdrValue("IMAGETYP", "fiber model")
         model.writeFitsData(os.path.join(masters_path, f"lvm-mmodel-{camera}.fits"))
-
-
-class lvmFlat(lvmFrame):
-    """lvmFlat class"""
-
-    def __init__(self, data=None, error=None, mask=None,
-                 cent_trace=None, width_trace=None, wave_trace=None, lsf_trace=None,
-                 header=None, slitmap=None, superflat=None, **kwargs):
-        lvmFrame.__init__(self, data=data, error=error, mask=mask,
-                     cent_trace=cent_trace, width_trace=width_trace,
-                     wave_trace=wave_trace, lsf_trace=lsf_trace,
-                     header=header, slitmap=slitmap, superflat=superflat)
-
-        self._blueprint = dp.load_blueprint(name="lvmFlat")
-        self._template = dp.dump_template(dataproduct_bp=self._blueprint, save=False)
 
 
 class lvmArc(lvmFrame):

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -505,6 +505,8 @@ def combine_twilight_sequence(in_fiberflats: List[str], out_fiberflat: str,
     mflat.set_wave_trace(TraceMask.from_spectrographs(*[TraceMask.from_file(in_wave) for in_wave in in_waves]))
     mflat.set_lsf_trace(TraceMask.from_spectrographs(*[TraceMask.from_file(in_lsf) for in_lsf in in_lsfs]))
     mflat = mflat.to_native_wave(method="linear", interp_density=False, return_density=False)
+    mflat._error = None
+    mflat._mask = None
     mflat.writeFitsData(out_fiberflat, replace_masked=False)
 
     return mflat

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -555,6 +555,9 @@ def fit_fiberflat(in_twilight: str, out_flat: str, out_rss: str,
             tck = interpolate.splrep(f._wave[mask], f._data[mask], s=0.1)
             new_flat._data[ifiber] = interpolate.splev(f._wave, tck)
 
+        # reset pixel mask
+        new_flat._mask[:] = new_flat._mask.all(axis=1)[:, None]
+
         flat_twilight = copy(twilight)
         flat_twilight._data = flat_twilight._data / new_flat._data
 
@@ -612,7 +615,7 @@ def fit_fiberflat(in_twilight: str, out_flat: str, out_rss: str,
 
     # write output fiberflat
     log.info(f"writing flat field to {out_flat}")
-    new_flat.writeFitsData(out_flat, replace_masked=False)
+    new_flat.writeFitsData(out_flat)
 
     # write output faltfielded explosure
     log.info(f"writing flatfielded twilight to {out_rss}")

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -18,7 +18,7 @@ from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 from lvmdrp import log
 from lvmdrp.core.constants import SPEC_CHANNELS
 from lvmdrp.core.tracemask import TraceMask
-from lvmdrp.core.spectrum1d import Spectrum1D
+from lvmdrp.core.spectrum1d import _cross_match_float, Spectrum1D
 from lvmdrp.core.rss import RSS, lvmFrame
 from lvmdrp.core.fluxcal import butter_lowpass_filter
 from lvmdrp.core import dataproducts as dp
@@ -267,23 +267,28 @@ def fit_fiberflat(in_twilight: str, out_flat: str, out_twilight: str,
     niter = max(1, niter)
     for i in range(niter):
         median_fiber = np.nanmedian(twilight._data, axis=0)
+        mask = np.isfinite(median_fiber)
+        median_fiber = np.interp(twilight._wave, twilight._wave[mask], median_fiber[mask])
         new_flat = copy(twilight)
-        new_flat._data = twilight._data / median_fiber[None]
+        # new_flat._data = twilight._data / median_fiber[None]
         for ifiber in range(new_flat._fibers):
             f = new_flat.getSpec(ifiber)
             if f._mask.all():
                 continue
 
-            # interpolating over masked pixels
-            mask = np.isfinite(f._data)
-            # f._data = np.interp(f._wave, f._wave[mask], f._data[mask])
+            # get selection of good pixels
+            f = f.interpolate_masked(mask=f._mask|~np.isfinite(f._data))
+
+            # correct median fiber to current fiber wavelength and normalize
+            _, shift, _ = _cross_match_float(ref_spec=median_fiber, obs_spec=f._data, stretch_factors=[1.0], shift_range=[-5,+5])
+            f._data /= np.interp(f._wave, f._wave+shift, median_fiber)
 
             # first filtering of high-frequency features
-            f._data[mask] = butter_lowpass_filter(f._data[mask], 0.1, 2)
+            f._data = butter_lowpass_filter(f._data, 0.1, 2)
             new_flat._data[ifiber] = f._data
 
             # further smoothing of remaining unwanted features
-            tck = interpolate.splrep(f._wave[mask], f._data[mask], s=0.1)
+            tck = interpolate.splrep(f._wave, f._data, s=0.1)
             new_flat._data[ifiber] = interpolate.splev(f._wave, tck)
 
         # reset pixel mask
@@ -313,9 +318,11 @@ def fit_fiberflat(in_twilight: str, out_flat: str, out_twilight: str,
     fig.suptitle(f"Flat fielding for {channel = }, {expnum = }")
     axs[0].set_title("Twilight", loc="left")
     axs[1].set_title(f"Flat field for fibers {','.join(map(str, plot_fibers))}", loc="left")
+    median_fiber = biweight_location(twilight._data, axis=0, ignore_nan=True)
     for ifiber in plot_fibers:
+        _, shift, _ = _cross_match_float(ref_spec=median_fiber, obs_spec=np.nan_to_num(twilight._data[ifiber]), stretch_factors=[1.0], shift_range=[-5,+5])
         ln, = axs[0].step(twilight._wave, twilight._data[ifiber], lw=1, where="mid")
-        axs[1].step(twilight._wave, twilight._data[ifiber] / np.nanmedian(twilight._data, axis=0), lw=1, color=ln.get_color(), where="mid")
+        axs[1].step(twilight._wave, twilight._data[ifiber] / np.interp(f._wave, f._wave+shift, median_fiber), lw=1, color=ln.get_color(), where="mid")
         axs[1].plot(new_flat._wave, new_flat._data[ifiber], lw=1, color=ln.get_color(), label=ifiber)
     axs[0].step(twilight._wave, median_fiber, lw=2, color="0.2", where="mid", label="median fiber")
     axs[0].legend(loc=1, frameon=False)

--- a/tests/functions/test_runtwilights.py
+++ b/tests/functions/test_runtwilights.py
@@ -75,7 +75,7 @@ def make_fake_rss(tileid=11111, mjd=61234, expnum=6817, cameras=None, imagetyp=N
 def test_fit_continuum():
     """ test continuum fitting """
     spectrum = make_fake_spectrum()
-    best_continuum, models, masked_pixels, tck = fit_continuum(spectrum, mask_bands=[(3100,3200)], median_box=1, niter=10, threshold=0.5)
+    best_continuum, models, masked_pixels, tck = fit_continuum(spectrum, mask_bands=[(3100,3200)], median_box=1, niter=10, threshold=0.5, knots=100)
     assert best_continuum.size == spectrum._data.size
     assert len(models) == 0
     assert masked_pixels.sum() == 12


### PR DESCRIPTION
This PR implements a significant improvement in flat fielding. Main changes are:

- Smoothing is carried out after normalizing fibers and not over the raw twilights
- Implemented Niv's optimization of convolution kernel in `convolution_matrix` and vectorization
- Added QA plot to show flat fielded fiber profile
- Other bug fixes and improvements

Example of new flat field in b

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/f852763f-4368-4165-9fbd-110f32fe2acf">

versus old one

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/9bbefa16-1c9e-44e5-91d4-7053c926c3ff">

The low-frequency features in the old flat field have been removed in this new implementation (fixes #88)