### PR TITLE
improves runtime of apply_hdrfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ distribute-*.tar.gz
 *~
 
 # Test directories and files
-data*
+#data*
 lib
 *.tar.gz*
 test-*.fits

--- a/tests/data/lvmHdrFix-60255.yaml
+++ b/tests/data/lvmHdrFix-60255.yaml
@@ -1,0 +1,29 @@
+schema:
+- description: the raw frame file root with * as wildcard
+  dtype: str
+  name: fileroot
+- description: the name of the header keyword to fix
+  dtype: str
+  name: keyword
+- description: the value of the header keyword to update
+  dtype: str
+  name: value
+fixes:
+- fileroot: sdR-*-*-00007334
+  keyword: SKYENAME
+  value: grid125
+- fileroot: sdR-*-b*-00007334
+  keyword: SKYWNAME
+  value: WHAM_south_08
+- fileroot: sdR-*-*2-0000732[4-6]
+  keyword: SKYENAME
+  value: grid103
+- fileroot: sdR-*-*2-0000732[4-6]
+  keyword: SKYWNAME
+  value: WHAM_south_02
+- fileroot: sdR-*-r1-00007329
+  keyword: SKYENAME
+  value: grid125
+- fileroot: sdR-*-r1-00007329
+  keyword: SKYWNAME
+  value: WHAM_south_02

--- a/tests/utils/test_hdrfix.py
+++ b/tests/utils/test_hdrfix.py
@@ -1,0 +1,82 @@
+
+
+import pathlib
+import pytest
+
+from lvmdrp.utils.hdrfix import read_hdrfix_file, apply_hdrfix, write_hdrfix_file
+
+
+# make fake hdr
+header = {
+    'MJD': 60255,
+    'CCD': 'b1',
+    'EXPOSURE': 7230,
+    'TILE_ID': 12345,
+    'OBSERVAT': 'LCO',
+    'SKYWNAME': 'old_west_name',
+    'SKYENAME': 'old_east_name',
+}
+
+
+@pytest.fixture()
+def mock_path(mocker):
+    """ fixture to mock the return path of the hdrfix file """
+    def _mock(mjd):
+        path = pathlib.Path(__file__).parent.parent / 'data' / f'lvmHdrFix-{mjd}.yaml'
+        mocker.patch('lvmdrp.utils.hdrfix.get_hdrfix_path', return_value=path)
+    return _mock
+
+
+def test_read_hdrfix_file(mock_path):
+    """ test we can read the hdrfix file """
+    mock_path(60255)
+    df = read_hdrfix_file(60255)
+    assert len(df) == 6
+    assert df['fileroot'].iloc[0] == 'sdR-*-*-00007334'
+    assert df['keyword'].iloc[0] == 'SKYENAME'
+    assert df['value'].iloc[0] == 'grid125'
+
+
+def test_read_hdrfix_file_no_file(mock_path):
+    """ test when the hdrfix file does not exist """
+    mock_path(60256)
+    df = read_hdrfix_file(60256)
+    assert df is None
+
+
+@pytest.mark.parametrize('input, exp',
+                         [(('b1', 7334), {'SKYWNAME': 'WHAM_south_08', 'SKYENAME': 'grid125'}),
+                          (('r1', 7334), {'SKYWNAME': 'old_west_name', 'SKYENAME': 'grid125'}),
+                          (('z1', 7330), {'SKYWNAME': 'old_west_name', 'SKYENAME': 'old_east_name'}),
+                          (('z2', 7324), {'SKYWNAME': 'WHAM_south_02', 'SKYENAME': 'grid103'}),
+                          (('b2', 7326), {'SKYWNAME': 'WHAM_south_02', 'SKYENAME': 'grid103'}),
+                          (('r3', 7326), {'SKYWNAME': 'old_west_name', 'SKYENAME': 'old_east_name'}),
+                          (('r1', 7329), {'SKYWNAME': 'WHAM_south_02', 'SKYENAME': 'grid125'}),
+                          (('z2', 7329), {'SKYWNAME': 'old_west_name', 'SKYENAME': 'old_east_name'}),
+                          ]
+                         )
+def test_apply_hdrfix(mock_path, input, exp):
+    """ test we can apply the hdrfix """
+    mock_path(60255)
+    hdr = header.copy()
+    hdr.update(dict(zip(['CCD', 'EXPOSURE'], input)))
+    new_hdr = apply_hdrfix(60255, hdr=hdr.copy())
+
+    assert new_hdr['SKYWNAME'] == exp['SKYWNAME']
+    assert new_hdr['SKYENAME'] == exp['SKYENAME']
+
+
+def test_write_hdrfix(tmp_path, mocker):
+    """ test we can write a new hdrfix file """
+    path = tmp_path / 'data' / 'lvmHdrFix-60257.yaml'
+    mocker.patch('lvmdrp.utils.hdrfix.get_hdrfix_path', return_value=path)
+
+    write_hdrfix_file(60257, 'sdR-*-*-00007334', 'SKYENAME', 'grid125')
+
+    read_hdrfix_file.cache_clear()
+    df = read_hdrfix_file(60257)
+    assert path.exists()
+    assert len(df) == 1
+    assert df['fileroot'].iloc[0] == 'sdR-*-*-00007334'
+    assert df['keyword'].iloc[0] == 'SKYENAME'
+    assert df['value'].iloc[0] == 'grid125'


### PR DESCRIPTION
This PR closes #123.  It improves the runtime of the `apply_hdrfix` function.    Adds some missing tests as well.

I profiled the `extract_metadata` function at Utah using MJD 60255, which has 1105 raw frame to process. Without the `apply_hdrfix`, `extract_metadata` takes 217 seconds to run, with the bulk of the time spent in `fits.getheader` (215 seconds).   With the original method, it took ~31000 seconds to run, with the bulk of the time spent in the `pathlib.Path.rglob` of `apply_hdrfix`.  This PR removes the pathlib rglob search and replaces it with an fnmatch check.  This reduces the time significantly.  With the  new `apply_hdrfix`, `extract_method` took 229 seconds to run, with the bulk time still spent in `fits.getheader`, 214 seconds with 13 seconds spent in `apply_hdrfix`.   
