### PR TITLE
Fixes failed tracing of edge fibers

### DIFF
--- a/python/lvmdrp/core/fiberrows.py
+++ b/python/lvmdrp/core/fiberrows.py
@@ -1093,7 +1093,7 @@ class FiberRows(Header, PositionTable):
         poly_all_table = []
         for i in range(self._fibers):
             good_pix = numpy.logical_not(self._mask[i, :])
-            good_sam = ~numpy.isnan(samples[i, :])
+            good_sam = numpy.isfinite(samples[i, :])
             if numpy.sum(good_pix) >= deg + 1 and good_sam.sum() / good_sam.size > min_samples_frac:
                 # select the polynomial class
                 poly_cls = Spectrum1D.select_poly_class(poly_kind)
@@ -1116,6 +1116,7 @@ class FiberRows(Header, PositionTable):
                     self._data = numpy.clip(self._data, clip[0], clip[1])
                 self._mask[i, :] = False
             else:
+                log.warning(f"fiber {i} does not meet criteria: {good_pix.sum() = } >= {deg + 1 = } or {good_sam.sum() / good_sam.size = } > {min_samples_frac = }")
                 self._mask[i, :] = True
 
         return numpy.asarray(pix_table), numpy.asarray(poly_table), numpy.asarray(poly_all_table)

--- a/python/lvmdrp/core/fiberrows.py
+++ b/python/lvmdrp/core/fiberrows.py
@@ -530,12 +530,12 @@ class FiberRows(Header, PositionTable):
         """
         if data_dim is not None:
             # create empty  data array and set number of fibers
-            self._data = numpy.zeros(data_dim, dtype=numpy.float32)
+            self._data = numpy.zeros(data_dim, dtype=numpy.float32) + numpy.nan
             self._fibers = self._data.shape[0]
 
         if data_dim is not None:
             # create empty  error array
-            self._error = numpy.zeros(data_dim, dtype=numpy.float32)
+            self._error = numpy.zeros(data_dim, dtype=numpy.float32) + numpy.nan
 
         if data_dim is not None:
             # create empty mask all pixel assigned bad

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -2311,9 +2311,9 @@ class Image(Header):
             fwhm_mask = numpy.isnan(fwhm_slice) | amp_off | cent_off | fwhm_off
 
             if amp_slice.size != trace_amp._data.shape[0]:
-                dummy_amp = numpy.split(numpy.zeros(trace_amp._data.shape[0]), nblocks)
-                dummy_cent = numpy.split(numpy.zeros(trace_cent._data.shape[0]), nblocks)
-                dummy_fwhm = numpy.split(numpy.zeros(trace_fwhm._data.shape[0]), nblocks)
+                dummy_amp = numpy.split(numpy.zeros(trace_amp._data.shape[0]) + numpy.nan, nblocks)
+                dummy_cent = numpy.split(numpy.zeros(trace_cent._data.shape[0]) + numpy.nan, nblocks)
+                dummy_fwhm = numpy.split(numpy.zeros(trace_fwhm._data.shape[0]) + numpy.nan, nblocks)
                 dummy_amp_mask = numpy.split(numpy.ones(trace_amp._data.shape[0], dtype=bool), nblocks)
                 dummy_cent_mask = numpy.split(numpy.ones(trace_cent._data.shape[0], dtype=bool), nblocks)
                 dummy_fwhm_mask = numpy.split(numpy.ones(trace_fwhm._data.shape[0], dtype=bool), nblocks)

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -3350,10 +3350,16 @@ class Spectrum1D(Header):
         fit_bg=True,
         warning=False,
     ):
-        error = self._error if self._error is not None else numpy.ones(self._dim, dtype=numpy.float32)
-        mask = self._mask if self._mask is not None else numpy.zeros(self._dim, dtype=bool)
-        error[mask] = numpy.inf
+        # copy main arrays to avoid side effects
         data = self._data.copy()
+        error = self._error.copy() if self._error is not None else numpy.ones(self._dim, dtype=numpy.float32)
+        mask = self._mask.copy() if self._mask is not None else numpy.zeros(self._dim, dtype=bool)
+
+        # update mask to account for unmasked invalid pixels
+        # mask |= (~numpy.isfinite(data) | ~numpy.isfinite(error))
+
+        # reset bad pixels in data and error
+        error[mask] = numpy.inf
         data[mask] = 0.0
 
         flux = numpy.ones(len(cent_guess)) * numpy.nan

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1335,9 +1335,9 @@ def create_traces(mjd, cameras=CAMERAS, use_longterm_cals=True, expnums_ldls=Non
                 mamps[camera]._data[select_block] = trace_flux_fit._data[select_block]
                 mcents[camera]._data[select_block] = trace_cent_fit._data[select_block]
                 mwidths[camera]._data[select_block] = trace_fwhm_fit._data[select_block]
-                mamps[camera]._mask[select_block] = False
-                mcents[camera]._mask[select_block] = False
-                mwidths[camera]._mask[select_block] = False
+                mamps[camera]._mask[select_block] = trace_flux_fit._mask[select_block]
+                mcents[camera]._mask[select_block] = trace_cent_fit._mask[select_block]
+                mwidths[camera]._mask[select_block] = trace_fwhm_fit._mask[select_block]
 
         mamp_path = path.full("lvm_master", drpver=drpver, tileid=tileid, mjd=mjd, camera=camera, kind="mamp")
         mcent_path = path.full("lvm_master", drpver=drpver, tileid=tileid, mjd=mjd, camera=camera, kind="mtrace")
@@ -1358,7 +1358,7 @@ def create_traces(mjd, cameras=CAMERAS, use_longterm_cals=True, expnums_ldls=Non
             mamps[camera]._mask[untraced_fibers] = True
             mcents[camera]._mask[untraced_fibers] = True
             mwidths[camera]._mask[untraced_fibers] = True
-            failed_fibers = (np.nansum(mcents[camera]._data, axis=1) == 0)|(np.nansum(mwidths[camera]._data, axis=1) == 0)
+            failed_fibers = (bn.nansum(mcents[camera]._data, axis=1) == 0)|(bn.nansum(mwidths[camera]._data, axis=1) == 0)
             mamps[camera]._mask[failed_fibers] = True
             mcents[camera]._mask[failed_fibers] = True
             mwidths[camera]._mask[failed_fibers] = True


### PR DESCRIPTION
Tracing of fibers can failed for different reasons but the pipeline should be able to fill in gaps using neighboring good fibers through interpolation. Failed edge fibers should be filled in by extrapolation. This PR fixes several issues preventing the behavior described above.

Main changes are:

- Better logging of failed traces
- Consistent values for invalid/non-sampled pixels (all NaNs)
- Fixes propagation of mask on failed fibers

This PR fixes #168.