### PR TITLE
Fixes race condition errors on writing DRPAll file

### DIFF
--- a/bin/drp
+++ b/bin/drp
@@ -12,7 +12,7 @@ import cloup
 from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
 
 from lvmdrp.core.constants import CALIBRATION_MATCH
-from lvmdrp.main import run_drp, reduce_file, check_daily_mjd, parse_mjds, read_expfile
+from lvmdrp.main import run_drp, reduce_file, check_daily_mjd, parse_mjds, read_expfile, create_drpall
 from lvmdrp.functions.skyMethod import configureSkyModel_drp
 from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
 from lvmdrp.utils.cluster import run_cluster
@@ -374,6 +374,15 @@ def cluster(mjd_list, mjd_range, expnum, exp_list, exp_range, exp_file, nodes, p
     # submit the cluster job
     run_cluster(mjds=mjds, expnums=expnums, nodes=nodes, ppn=ppn, walltime=walltime, alloc=alloc, submit=submit,
                 run_calibs=run_calibs, drp_options=drp_options)
+
+
+@cli.command('summary', short_help='Creates the drpall summary file for the given version of the pipeline')
+@click.option('--drp-version', type=str, default=None, help='DRP version for which a drpall summary file will be created')
+@click.option('-o', '--overwrite', is_flag=True, default=False, help='Overwrites any existing drpall file before creating a new one')
+def summary(drp_version, overwrite):
+    """ Creates the DRP summary file for a given version of the DRP """
+
+    create_drpall(drp_version=drp_version, overwrite=overwrite)
 
 
 if __name__ == "__main__":

--- a/bin/drp
+++ b/bin/drp
@@ -122,13 +122,14 @@ def cli():
 @click.option('-2d', '--skip-2d', is_flag=True, default=False, help='Skip preprocessing and detrending')
 @click.option('-1d', '--skip-1d', is_flag=True, default=False, help='Skip astrometry, straylight subtraction and extraction')
 @click.option('-p1d', '--skip-post-1d', is_flag=True, default=False, help='Skip wavelength calibration, flatfielding, sky processing and flux calibration')
+@click.option('-da', '--skip-drpall', is_flag=True, default=False, help='Skip create/update drpall summary file')
 @click.option('-c', '--clean-ancillary', is_flag=True, default=False, help='Remove ancillary paths after run')
 @click.option('-d', '--debug-mode', is_flag=True, default=False, help='Set debug mode on to run using aperture extraction and skip CR rejection')
 @cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
 # @cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
 @cloup.constraint(mutually_exclusive, ['expnum', 'exp_list', 'exp_range'])
 def run(mjd, mjd_list, mjd_range, with_cals, no_sci, expnum, exp_list, exp_range, exp_file, fluxcal_method,
-        skip_2d, skip_1d, skip_post_1d, clean_ancillary, debug_mode):
+        skip_2d, skip_1d, skip_post_1d, skip_drpall, clean_ancillary, debug_mode):
     """ Run the DRP reduction for a given MJD or range of MJDs
 
     Run the DRP for an MJD or range of MJDs.  Various flags and options are available
@@ -149,6 +150,7 @@ def run(mjd, mjd_list, mjd_range, with_cals, no_sci, expnum, exp_list, exp_range
             skip_2d=skip_2d,
             skip_1d=skip_1d,
             skip_post_1d=skip_post_1d,
+            skip_drpall=skip_drpall,
             clean_ancillary=clean_ancillary,
             debug_mode=debug_mode)
 

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -1465,6 +1465,7 @@ def science_reduction(expnum: int, use_longterm_cals: bool = False,
                       skip_2d: bool = False,
                       skip_1d: bool = False,
                       skip_post_1d: bool = False,
+                      skip_drpall: bool = False,
                       debug_mode: bool = False) -> None:
     """ Run the science reduction for a given exposure number.
     """
@@ -1639,6 +1640,9 @@ def science_reduction(expnum: int, use_longterm_cals: bool = False,
         with Timer(name='QSky '+sframe_path, logger=log.info):
             quick_sky_subtraction(in_cframe=cframe_path, out_sframe=sframe_path)
 
+    if skip_drpall:
+        log.info("skipping create/update drpall summary file")
+    else:
         # update the drpall summary file
         with Timer(name='DRPAll '+sframe_path, logger=log.info):
             log.info('Updating the drpall summary file')
@@ -1676,7 +1680,8 @@ def science_reduction(expnum: int, use_longterm_cals: bool = False,
 
 def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
             with_cals: bool = False, no_sci: bool = False,
-            fluxcal_method: str = 'STD', skip_2d: bool = False, skip_1d: bool = False, skip_post_1d: bool = False,
+            fluxcal_method: str = 'STD',
+            skip_2d: bool = False, skip_1d: bool = False, skip_post_1d: bool = False, skip_drpall: bool = False,
             clean_ancillary: bool = False, debug_mode: bool = False):
     """ Run the quick DRP
 
@@ -1704,6 +1709,8 @@ def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
         Skip astrometry, straylight subtraction and extraction, by default False
     skip_post_1d : bool, optional
         Skip wavelength calibration, flatfielding, sky processing and flux calibration
+    skip_drpall : bool, optional
+        Skip create/update drpall summary file
     clean_ancillary : bool, optional
         Flag to remove the ancillary paths, by default False
     debug_mode : bool, optional
@@ -1726,6 +1733,7 @@ def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
                     skip_2d=skip_2d,
                     skip_1d=skip_1d,
                     skip_post_1d=skip_post_1d,
+                    skip_drpall=skip_drpall,
                     clean_ancillary=clean_ancillary,
                     debug_mode=debug_mode)
         return
@@ -1809,6 +1817,7 @@ def run_drp(mjd: Union[int, str, list], expnum: Union[int, str, list] = None,
                                         skip_2d=skip_2d,
                                         skip_1d=skip_1d,
                                         skip_post_1d=skip_post_1d,
+                                        skip_drpall=skip_drpall,
                                         clean_ancillary=clean_ancillary,
                                         debug_mode=debug_mode, **kwargs)
                     except Exception as e:

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -1853,15 +1853,16 @@ def create_drpall(drp_version: str = None, overwrite: bool = False) -> None:
 
     # define lvmSFrame paths
     sframe_paths = path.expand("lvm_frame", kind="SFrame", drpver=drp_version, tileid="*", mjd="*", expnum=8*"?")
-    log.info(f"found {len(sframe_paths)} lvmSFrames")
+    log.info(f"found {len(sframe_paths)} lvmSFrames under {drp_version = }")
     # iterate over each file and create/update the drpall file
     for sframe_path in sframe_paths:
+        log.info(f"processing lvmSFrame {sframe_path}")
         # extract Tile ID, MJD and exposure number from file
         # pars = path.extract("lvm_frame", sframe_path)
         pars = sframe_path.split(".fits")[0].split("/")
         tileid, mjd, expnum = int(pars[-3]), int(pars[-2]), int(pars[-1].split("-")[-1])
         cals_mjd = get_master_mjd(mjd)
-        update_summary_file(sframe_path, tileid=tileid, mjd=mjd, expnum=expnum, master_mjd=cals_mjd)
+        update_summary_file(sframe_path, tileid=tileid, mjd=mjd, expnum=expnum, master_mjd=cals_mjd, drpver=drp_version)
 
 
 def reduce_calib_frame(row: dict):

--- a/python/lvmdrp/utils/cluster.py
+++ b/python/lvmdrp/utils/cluster.py
@@ -68,6 +68,9 @@ def run_cluster(mjds: list = None, expnums: Union[list, str] = None, nodes: int 
     if run_calibs:
         expnums = None
         cmd = "calibrations"
+    else:
+        # skip drpall summary file in cluster runs to avoid race condition errors
+        drp_options += " --skip-drpall" if "--skip-drpall" not in drp_options else ""
 
     if expnums is not None:
         if isinstance(expnums, str) and os.path.isfile(expnums):

--- a/python/lvmdrp/utils/metadata.py
+++ b/python/lvmdrp/utils/metadata.py
@@ -1544,7 +1544,11 @@ def update_summary_file(filename: str, tileid: int = None, mjd: int = None, expn
     df = df.astype(dtypes)
 
     # replace empty strings in object column with None
-    df['object'] = df['object'].replace('', None)
+    df['object'] = df['object'].fillna('NA')
+    df['skye_name'] = df['skye_name'].fillna('NA')
+    df['skyw_name'] = df['skyw_name'].fillna('NA')
+    # replace NaN values by invalid value -999 (NaNs will be casted to strings)
+    df.fillna(-999.9, inplace=True)
 
     # create drpall h5 filepath
     drpall = path.full('lvm_drpall', drpver=drpver)
@@ -1554,7 +1558,7 @@ def update_summary_file(filename: str, tileid: int = None, mjd: int = None, expn
 
     # set min column sizes for some columns
     min_itemsize = {'skye_name': 20, 'skyw_name': 20, 'location': 120, 'agcam_location': 120,
-                    'object': 16, 'obstime': 23}
+                    'object': 24, 'obstime': 23}
 
     # write to pytables hdf5
     try:

--- a/python/lvmdrp/utils/metadata.py
+++ b/python/lvmdrp/utils/metadata.py
@@ -1538,17 +1538,18 @@ def update_summary_file(filename: str, tileid: int = None, mjd: int = None, expn
     # explicitly set some column dtypes to try and handle cases with null data
     # sci, skye, skye keys
     tels = {'sci', 'skye', 'skyw'}
-    keys = {'ra', 'dec', 'amass', 'kmpos', 'focpos'}
+    keys = {'ra', 'dec', 'amass', 'kmpos', 'focpos', 'sh_hght', 'moon_sep'}
     dtypes = {f'{i}_{j}': 'float64' for i, j in itertools.product(tels, keys)}
+    dtypes.update({colname: 'float64' for colname in ('moon_ra', 'moon_dec', 'moon_phase', 'moon_fli', 'sun_alt', 'moon_alt')})
     dtypes['calib_mjd'] = 'int64'
     df = df.astype(dtypes)
 
     # replace empty strings in object column with None
-    df['object'] = df['object'].fillna('NA')
-    df['skye_name'] = df['skye_name'].fillna('NA')
-    df['skyw_name'] = df['skyw_name'].fillna('NA')
+    df['object'] = df['object'].fillna('None')
+    df['skye_name'] = df['skye_name'].fillna('None')
+    df['skyw_name'] = df['skyw_name'].fillna('None')
     # replace NaN values by invalid value -999 (NaNs will be casted to strings)
-    df.fillna(-999.9, inplace=True)
+    df.fillna(-999, inplace=True)
 
     # create drpall h5 filepath
     drpall = path.full('lvm_drpall', drpver=drpver)


### PR DESCRIPTION
This PR replaces the creation/updating of the drpall summary file in cluster runs to prevent #166.

Main changes are:
- Implemented optional version parameter for metadata routines
- Implemented optional skipping of drpall file creation
- By default skipping drpall creation in cluster runs
- Implemented CLI to create drpall files for the given versions
- Better handling of invalid values to avoid casting float into strings and viceversa

This changes imply that we now have to run the creation of the drpall file after the cluster run are done.
This PR fixes #166.