### PR TITLE
Fixing wavelength and LSF fitting for 60177

### DIFF
--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -311,6 +311,11 @@ def determine_wavelength_solution(in_arcs: List[str]|str, out_wave: str, out_lsf
     # update lamps status
     lamps = set(ilamps)
 
+    # # mask std fibers since they are not regularly illuminated during arc exposures
+    # fibermap = arc._slitmap[arc._slitmap["spectrographid"] == int(camera[1])]
+    # select = fibermap["telescope"] == "Spec"
+    # arc._mask[select] = True
+
     # subtract continuum
     if cont_niter > 0:
         log.info(f"fitting and subtracting continuum with parameters: {cont_niter = }, {cont_thresh = }, {cont_box_range = }")

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -1873,14 +1873,14 @@ def create_drpall(drp_version: str = None, overwrite: bool = False) -> None:
             log.info(f"no drpall file found for {drp_version = }")
 
     # define lvmSFrame paths
-    sframe_paths = path.expand("lvm_frame", kind="SFrame", drpver=drp_version, tileid="*", mjd="*", expnum=8*"?")
+    sframe_paths = sorted(path.expand("lvm_frame", kind="SFrame", drpver=drp_version, tileid="*", mjd="*", expnum=8*"?"))
     nframes = len(sframe_paths)
     log.info(f"found {nframes} lvmSFrames under {drp_version = }")
     # iterate over each file and create/update the drpall file
     nfailed = 0
     failed = []
-    for sframe_path in sframe_paths:
-        log.info(f"{sframe_path = }")
+    for iframe, sframe_path in enumerate(sframe_paths):
+        log.info(f"[{iframe+1}/{nframes}] {sframe_path = }")
         # extract Tile ID, MJD and exposure number from file
         # pars = path.extract("lvm_frame", sframe_path)
         pars = sframe_path.split(".fits")[0].split("/")


### PR DESCRIPTION
This PR fixes issues with calibrations in epoch 60177. Main changes are:

- Implementing of interpolation of missing guess centroids
- Implementing determination of exposed standard fiber in arc exposure

With these changes we are always ensuring a guess centroid for the arc line measurements and that we skip standard fibers that were not exposed. Both will have an impact on calibrations for other epochs as well.