### PR TITLE
Refined thermal shift measurements

### DIFF
--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -767,7 +767,7 @@ class Image(Header):
             _, shifts[j], _ = _cross_match_float(s1, s2, numpy.array([1.0]), shift_range, gauss_window=[-3,3], min_peak_dist=5.0, ax=axs_cc[j])
 
             blocks_pos = numpy.asarray(numpy.split(trace_cent._data[:, c], 18))[select_blocks]
-            blocks_bounds = [(int(bpos.min())-5, int(bpos.max())+5) for bpos in blocks_pos]
+            blocks_bounds = [(int(bpos.min())-10, int(bpos.max())+10) for bpos in blocks_pos]
 
             for i, (bmin, bmax) in enumerate(blocks_bounds):
                 x = numpy.arange(bmax-bmin) + i*(bmax-bmin) + 10
@@ -777,7 +777,8 @@ class Image(Header):
                 # y_data, _, _ = _normalize_peaks(y_data, min_peak_dist=5.0)
                 axs_fb[j].step(x, y_data, color="0.2", lw=1.5, label="data" if i == 0 else None)
                 axs_fb[j].step(x, y_model, color="tab:blue", lw=1, label="model" if i == 0 else None)
-                axs_fb[j].step(x+shifts[j], numpy.interp(x+shifts[j], x, y_model), color="tab:red", lw=1, label="corr. model" if i == 0 else None)
+                # axs_fb[j].step(x+shifts[j], numpy.interp(x+shifts[j], x, y_model), color="tab:red", lw=1, label="corr. model" if i == 0 else None)
+                axs_fb[j].step(x, numpy.interp(x, x+shifts[j], y_model), color="tab:red", lw=1, label="corr. model" if i == 0 else None)
             axs_fb[j].set_title(f"measured shift {shifts[j]:.4f} pixel @ column {c} with SNR = {median_snr:.2f}")
             axs_fb[j].set_ylim(-0.05, 1.3)
         axs_fb[0].legend(loc=1, frameon=False, ncols=3)

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -23,7 +23,7 @@ from lvmdrp.core.fit_profile import gaussians, Gaussians
 from lvmdrp.core.apertures import Apertures
 from lvmdrp.core.header import Header
 from lvmdrp.core.tracemask import TraceMask
-from lvmdrp.core.spectrum1d import Spectrum1D, _normalize_peaks, _cross_match_float, _cross_match, _spec_from_lines, align_blocks
+from lvmdrp.core.spectrum1d import Spectrum1D, _normalize_peaks, _fiber_cc_match, _cross_match, _spec_from_lines, align_blocks
 
 from cextern.fast_median.fast_median import fast_median_filter_2d
 
@@ -772,7 +772,7 @@ class Image(Header):
                 shifts[j] = numpy.nan
                 continue
 
-            _, shifts[j], _ = _cross_match_float(s1, s2, numpy.array([1.0]), guess_shift, shift_range, gauss_window=[-3,3], min_peak_dist=5.0, ax=axs_cc[j])
+            _, shifts[j], _ = _fiber_cc_match(s1, s2, guess_shift, shift_range, gauss_window=[-3,3], min_peak_dist=5.0, ax=axs_cc[j])
 
             blocks_pos = numpy.asarray(numpy.split(trace_cent._data[:, c], 18))[select_blocks]
             blocks_bounds = [(int(bpos.min())-10, int(bpos.max())+10) for bpos in blocks_pos]

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -756,7 +756,7 @@ class Image(Header):
             snr = numpy.sqrt(s2)
             median_snr = bn.nanmedian(snr)
 
-            min_snr = 5.0
+            min_snr = 1.0
             if median_snr <= min_snr:
                 comstr = f"low SNR (<={min_snr}) for thermal shift at column {c}: {median_snr:.4f}, assuming = NaN"
                 log.warning(comstr)
@@ -773,8 +773,8 @@ class Image(Header):
                 x = numpy.arange(bmax-bmin) + i*(bmax-bmin) + 10
                 y_model = bn.nanmedian(ref_data[bmin:bmax, c-column_width:c+column_width], axis=1)
                 y_data = bn.nanmedian(self._data[bmin:bmax, c-column_width:c+column_width], axis=1)
-                y_model = _normalize_peaks(y_model, min_peak_dist=5.0)
-                y_data = _normalize_peaks(y_data, min_peak_dist=5.0)
+                y_data, y_model, _, _, _, _ = _normalize_peaks(y_data, y_model, min_peak_dist=5.0)
+                # y_data, _, _ = _normalize_peaks(y_data, min_peak_dist=5.0)
                 axs_fb[j].step(x, y_data, color="0.2", lw=1.5, label="data" if i == 0 else None)
                 axs_fb[j].step(x, y_model, color="tab:blue", lw=1, label="model" if i == 0 else None)
                 axs_fb[j].step(x+shifts[j], numpy.interp(x+shifts[j], x, y_model), color="tab:red", lw=1, label="corr. model" if i == 0 else None)

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -616,6 +616,7 @@ def plot_fiber_thermal_shift(columns, column_shifts, median_shift, std_shift, ax
     ax.set_title("Y shifts for each column")
     ax.set_xlabel("X (pixel)")
     ax.set_ylabel("Y shift (pixel)")
+    ax.set_ylim(median_shift-4*std_shift, median_shift+4*std_shift)
 
     if labels:
         ax.annotate(f"mean: {median_shift:.2f}", (0.9, 0.9), xycoords="axes fraction", ha="right", va="top", color="tab:red")

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -282,10 +282,10 @@ def _choose_cc_peak(cc, shifts, min_shift, max_shift):
         # sum_cc.append(area)
 
 
-    print(ccp, sum_cc)
+    # print(ccp, sum_cc)
     return ccp[numpy.argmax(sum_cc)]
 
-def align_blocks(obs_spec, ref_spec, median_box=21):
+def align_blocks(ref_spec, obs_spec, median_box=21):
     """Cross-correlate median-filtered versions of fiber profile data and model to get coarse alignment"""
     obs_median = signal.medfilt(obs_spec, median_box)
     ref_median = signal.medfilt(ref_spec, median_box)
@@ -305,6 +305,7 @@ def _cross_match_float(
     ref_spec: numpy.ndarray,
     obs_spec: numpy.ndarray,
     stretch_factors: numpy.ndarray,
+    guess_shift : int,
     shift_range: List[int],
     min_peak_dist: float = 5.0,
     gauss_window: List[int] = [-10, 10],
@@ -331,6 +332,8 @@ def _cross_match_float(
         The observed spectrum.
     stretch_factors : ndarray
         The stretch factors to use.
+    guess_shift : int
+        Guess for the best CC shift
     shift_range : tuple
         The range of shifts to use.
     min_peak_dist : float, optional
@@ -379,11 +382,6 @@ def _cross_match_float(
         elif len_diff < 0:
             # Or crop the stretched signal at the end if it's longer
             stretched_signal1 = stretched_signal1[:len_diff]
-
-        guess_shift = align_blocks(obs_spec_, stretched_signal1)
-
-        if guess_shift > 6:
-            log.warning(f"measuring fiber thermal shift too large {guess_shift = } pixels")
 
         # Get the correlation shifts
         shifts = signal.correlation_lags(

--- a/python/lvmdrp/functions/imageMethod.py
+++ b/python/lvmdrp/functions/imageMethod.py
@@ -2603,8 +2603,8 @@ def extract_spectra(
     else:
         fiber_model = None
 
-    shift_range = [-7,7]
-    fig = plt.figure(figsize=(15, 3*len(columns)), layout="constrained")
+    shift_range = [-4,4]
+    fig = plt.figure(figsize=(15, 4*len(columns)), layout="constrained")
     fig.suptitle(f"Thermal fiber shifts for {mjd = }, {camera = }, {expnum = }")
     gs = GridSpec(len(columns)+1, 15, figure=fig)
     axs_cc, axs_fb = [], []
@@ -2619,7 +2619,7 @@ def extract_spectra(
     axs_cc[0].set_title("Cross-correlation")
     axs_cc[-1].set_xlabel("Shift (pixel)")
     axs_fb[-1].set_xlabel("Y (pixel)")
-    axs_cc[-1].set_xlim(shift_range)
+    # axs_cc[-1].set_xlim(shift_range)
 
     # fix centroids for thermal shifts
     log.info(f"measuring fiber thermal shifts @ columns: {','.join(map(str, columns))}")

--- a/python/lvmdrp/functions/imageMethod.py
+++ b/python/lvmdrp/functions/imageMethod.py
@@ -2603,7 +2603,7 @@ def extract_spectra(
     else:
         fiber_model = None
 
-    shift_range = [-4,4]
+    shift_range = [-7,7]
     fig = plt.figure(figsize=(15, 3*len(columns)), layout="constrained")
     fig.suptitle(f"Thermal fiber shifts for {mjd = }, {camera = }, {expnum = }")
     gs = GridSpec(len(columns)+1, 15, figure=fig)


### PR DESCRIPTION
in v1.1.0 some tile reductions failed to measure correctly both thermal shifts in Y and X directions. This PR implements a features in `_fix_fiber_thermal_shifts` and `shift_wave_skylines` to make those measurements more robust against large thermal shifts.