### PR TITLE
Setting single source of ephemeris at lvmcore

### DIFF
--- a/python/lvmdrp/core/constants.py
+++ b/python/lvmdrp/core/constants.py
@@ -60,9 +60,8 @@ SKYMODEL_MODEL_CONFIG_PATH = os.path.join(
 # ESO skycorr configuration file
 SKYCORR_CONFIG_PATH = os.path.join(CONFIG_PATH, "third_configs", "skycorr_config.yml")
 
-# data paths
-DATA_PATH = os.path.join(ROOT_PATH, "data")
-EPHEMERIS_PATH = os.path.join(DATA_PATH, "de421.bsp")
+# ephemeris path
+EPHEMERIS_DIR = os.path.join(os.getenv("LVMCORE_DIR"), "etc")
 
 # fiducial calibrations directory
 MASTERS_DIR = os.getenv("LVM_MASTER_DIR")

--- a/python/lvmdrp/core/sky.py
+++ b/python/lvmdrp/core/sky.py
@@ -27,14 +27,14 @@ from skycalc_cli.skycalc import AlmanacQuery, SkyModel
 from skycalc_cli.skycalc_cli import fixObservatory
 from skyfield import almanac
 from skyfield.positionlib import ICRS
-from skyfield.api import Star, load, wgs84
+from skyfield.api import Loader, Star, load, wgs84
 from skyfield.framelib import ecliptic_frame
 
 from lvmdrp.external import shadow_height_lib as sh
 
 from lvmdrp.core.constants import (
     ALMANAC_CONFIG_PATH,
-    EPHEMERIS_PATH,
+    EPHEMERIS_DIR,
     SKYCALC_CONFIG_PATH,
     SKYCORR_CONFIG_PATH,
     SKYCORR_INST_PATH,
@@ -256,7 +256,8 @@ def skymodel_pars_header(header):
     obstime = Time(header["OBSTIME"], scale="tai")
 
     # define ephemeris object
-    astros = load(os.path.basename(EPHEMERIS_PATH))
+    ephemeris_loader = Loader(EPHEMERIS_DIR)
+    astros = ephemeris_loader("de421.bsp")
     sun, earth, moon = astros["sun"], astros["earth"], astros["moon"]
     # define location
     obs_topos = wgs84.latlon(
@@ -266,7 +267,7 @@ def skymodel_pars_header(header):
     )
     obs = earth + obs_topos
     # define observation datetime
-    ts = load.timescale()
+    ts = ephemeris_loader.timescale()
     obs_time = ts.from_astropy(obstime)
     # define observatory object
     obs = obs.at(obs_time)

--- a/python/lvmdrp/external/shadow_height_lib.py
+++ b/python/lvmdrp/external/shadow_height_lib.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
 import numpy as np
-import os
 import sys
 from astropy import units as u
 from skyfield.api import Loader
 from skyfield.api import Topos
+
+from lvmdrp.core.constants import EPHEMERIS_DIR
 
 class shadow_calc(object):
     def __init__(self, observatory_name="LCO",
@@ -21,9 +22,8 @@ class shadow_calc(object):
         super().__init__()
 
         # Load the ephemeral datat for the earth and sun.
+        load = Loader(EPHEMERIS_DIR)
         if eph is None:
-            redux = os.getenv("LVM_SPECTRO_REDUX")
-            load = Loader(redux)
             self.eph = load('de421.bsp')
 
         # Get functions for the earth, sun and observatory
@@ -343,8 +343,7 @@ def test_shadow_calc():
 
     compare_old = True
     if compare_old:
-        redux = os.getenv("LVM_SPECTRO_REDUX")
-        load = Loader(redux)
+        load = Loader(EPHEMERIS_DIR)
         eph = load('de421.bsp')
         import lvmsurveysim.utils.iterative_shadow_height_lib as iterative_shadow_height_lib
         iter_calc = iterative_shadow_height_lib.shadow_calc(observatory_name='LCO',


### PR DESCRIPTION
Implementing single source for "de421.bsp" ephemeris file across the pipeline. Main changes:

- Defined path to ephemeris as constant pointing to `lvmcore/etc`
- Setup loader to this single source for SH and sky parameter calculations
- Fixed potential issue with loader being defined within conditional and referenced later