### PR TITLE
Improved flux calibration method selection

### DIFF
--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -462,9 +462,14 @@ def fluxcal_standard_stars(in_rss, plot=True, GAIA_CACHE_DIR=None):
 
     label = rss._header['CCD']
     channel = label.lower()
-    rss.setHdrValue(f"STDSENM{label}", np.nanmean(mean_std[1000:3000]), f"mean stdstar sensitivity in {channel}")
-    rss.setHdrValue(f"STDSENR{label}", np.nanmean(rms_std[1000:3000]), f"mean stdstar sensitivity rms in {channel}")
-    log.info(f"Mean stdstar sensitivity in {channel} : {np.nanmean(mean_std[1000:3000])}")
+
+    mean_std_band = np.nanmean(mean_std[1000:3000])
+    rms_std_band = np.nanmean(rms_std[1000:3000])
+    mean_std_band = -999.9 if np.isnan(mean_std_band) else mean_std_band
+    rms_std_band = -999.9 if np.isnan(rms_std_band) else rms_std_band
+    rss.setHdrValue(f"SCISENM{label}", mean_std_band, f"mean stdstar sensitivity in {channel}")
+    rss.setHdrValue(f"SCISENR{label}", rms_std_band, f"mean stdstar sensitivity rms in {channel}")
+    log.info(f"Mean stdstar sensitivity in {channel} : {mean_std_band}")
 
     if plot:
         plt.ylabel("sensitivity [(ergs/s/cm^2/A) / (e-/s/A)]")

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -121,7 +121,7 @@ def apply_fluxcal(in_rss: str, out_fframe: str, method: str = 'STD', display_plo
 
     # fall back to science ifu field stars if above failed or if instructed to use this method
     if method == 'SCI':
-        log.info("flux-calibratimg using SCI field stars")
+        log.info("flux-calibrating using SCI field stars")
         sens_arr = fframe._fluxcal_sci.to_pandas().values  # * (std_exp / std_exp.sum())[None]
         sens_ave = biweight_location(sens_arr, axis=1, ignore_nan=True)
         sens_rms = biweight_scale(sens_arr, axis=1, ignore_nan=True)
@@ -453,7 +453,6 @@ def fluxcal_standard_stars(in_rss, plot=True, GAIA_CACHE_DIR=None):
     if ngood_std < 8:
         log.warning("less than 8 good standard fibers, skipping standard calibration")
         rss.add_header_comment("less than 8 good standard fibers, skipping standard calibration")
-        res_std[:] = np.nan
         rss.set_fluxcal(fluxcal=res_std, source='std')
         rss.writeFitsData(in_rss)
         return res_std, mean_std, rms_std, rss


### PR DESCRIPTION
This PR implements a better selection of the flux calibration selection by comparing the average sensitivity.

Main changes are:
- Once the average sensitivity is calculated for standard and science, it selects the method with the best (<1e-12) sensitivity
- Adds the missing average and RMS sensitivity to the `FLUXCAL_SCI` table
- Preserves the standard sensitivities even if <8 standard stars
- Fixes NaN in standard sensitivity header keywords
- Selection of calibration method happens in one routine