### PR TITLE
New fiber flat fielding

### DIFF
--- a/bin/drp
+++ b/bin/drp
@@ -300,9 +300,10 @@ cli.add_command(calibrations)
 @click.option('-m', '--mjd', type=int, required=True, help='an MJD for which fiberflats will be corrected')
 @click.option('-l', '--science-mjds', type=IntListType(), required=True, help='a list of specific MJDs to reduce')
 @click.option('-e', '--science-expnums', type=IntListType(), default=None, help='a list of specific exposure numbers to reduce')
+@click.option('--force-correction', is_flag=True, default=False, help='flag to force correction even if has been already done')
 @click.option('-s', '--skip-done', is_flag=True, default=False, help='flag to skip reduction steps that have already been done')
-def fiberflat_corrections(mjd, science_mjds, science_expnums, skip_done):
-    create_fiberflats_corrections(mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums, skip_done=skip_done)
+def fiberflat_corrections(mjd, science_mjds, science_expnums, force_correction, skip_done):
+    create_fiberflats_corrections(mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums, force_correction=force_correction, skip_done=skip_done)
 
 # register fiberflat correction routine
 cli.add_command(fiberflat_corrections)

--- a/bin/drp
+++ b/bin/drp
@@ -23,7 +23,8 @@ from lvmdrp.functions.run_calseq import (
     reduce_nightly_sequence,
     reduce_longterm_sequence,
     fix_raw_pixel_shifts,
-    copy_longterm_calibrations)
+    copy_longterm_calibrations,
+    create_fiberflats_corrections)
 
 from sdss_access import Access
 
@@ -293,6 +294,18 @@ def calibrations(mjd, mjd_list, mjd_range, reject_cr,
 
 # register calibration sequence
 cli.add_command(calibrations)
+
+
+@cli.command('fiberflat-corrections', short_help='Run fiberflat skyline correction using science frames', context_settings=dict(show_default=True))
+@click.option('-m', '--mjd', type=int, required=True, help='an MJD for which fiberflats will be corrected')
+@click.option('-l', '--science-mjds', type=IntListType(), required=True, help='a list of specific MJDs to reduce')
+@click.option('-e', '--science-expnums', type=IntListType(), default=None, help='a list of specific exposure numbers to reduce')
+@click.option('-s', '--skip-done', is_flag=True, default=False, help='flag to skip reduction steps that have already been done')
+def fiberflat_corrections(mjd, science_mjds, science_expnums, skip_done):
+    create_fiberflats_corrections(mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums, skip_done=skip_done)
+
+# register fiberflat correction routine
+cli.add_command(fiberflat_corrections)
 
 
 @cli.command('fix-pixel-shifts', short_help='Fix the electronic pixel shifts in the raw data')

--- a/python/lvmdrp/core/constants.py
+++ b/python/lvmdrp/core/constants.py
@@ -131,3 +131,18 @@ LVM_NBLOCKS = 18
 LVM_REFERENCE_COLUMN = 2000
 FIDUCIAL_PLATESCALE = 112.36748321030637 # Focal plane platescale in "/mm
 
+# GB hand picked isolated bright lines across each channel which are not doublest in UVES atlas
+# true wavelengths taken from UVES sky line atlas
+REF_SKYLINES = {
+    'b':[5577.346680],
+    'r':[6363.782715, 7358.680176, 7392.209961],
+    'z':[8399.175781, 8988.383789, 9552.546875, 9719.838867]
+}
+
+# sky lines to fit spec-to-spec flat field factors
+SKYLINES_FIBERFLAT = {
+    "b": 5577.346680,
+    "r": 6363.782715,
+    "z": 9552.546875
+}
+

--- a/python/lvmdrp/core/constants.py
+++ b/python/lvmdrp/core/constants.py
@@ -134,9 +134,9 @@ FIDUCIAL_PLATESCALE = 112.36748321030637 # Focal plane platescale in "/mm
 # GB hand picked isolated bright lines across each channel which are not doublest in UVES atlas
 # true wavelengths taken from UVES sky line atlas
 REF_SKYLINES = {
-    'b':[5577.346680],
-    'r':[6363.782715, 7358.680176, 7392.209961],
-    'z':[8399.175781, 8988.383789, 9552.546875, 9719.838867]
+    "b": [5577.346680],
+    "r": [6363.782715, 7358.680176, 7392.209961],
+    "z": [8399.175781, 8988.383789, 9552.546875, 9719.838867]
 }
 
 # sky lines to fit spec-to-spec flat field factors
@@ -146,3 +146,9 @@ SKYLINES_FIBERFLAT = {
     "z": 9552.546875
 }
 
+# continuum wavelengths
+CONTINUUM_FIBERFLAT = {
+    "b": 4600,
+    "r": 6760,
+    "z": 8170
+}

--- a/python/lvmdrp/core/constants.py
+++ b/python/lvmdrp/core/constants.py
@@ -142,7 +142,7 @@ REF_SKYLINES = {
 # sky lines to fit spec-to-spec flat field factors
 SKYLINES_FIBERFLAT = {
     "b": 5577.346680,
-    "r": 6363.782715,
+    "r": 7392.209961,
     "z": 9552.546875
 }
 

--- a/python/lvmdrp/core/constants.py
+++ b/python/lvmdrp/core/constants.py
@@ -142,8 +142,8 @@ REF_SKYLINES = {
 # sky lines to fit spec-to-spec flat field factors
 SKYLINES_FIBERFLAT = {
     "b": 5577.346680,
-    "r": 7392.209961,
-    "z": 9552.546875
+    "r": 6363.782715,
+    "z": 8399.175781
 }
 
 # continuum wavelengths

--- a/python/lvmdrp/core/fiberrows.py
+++ b/python/lvmdrp/core/fiberrows.py
@@ -168,15 +168,7 @@ class FiberRows(Header, PositionTable):
         if isinstance(other, self.__class__):
             # define behaviour if the other is of the same instance
 
-            img = self.__class__(
-                header=self._header,
-                shape=self._shape,
-                size=self._size,
-                arc_position_x=self._arc_position_x,
-                arc_position_y=self._arc_position_y,
-                good_fibers=self._good_fibers,
-                fiber_type=self._fiber_type,
-            )
+            img = copy(self)
 
             # subtract data if contained in both
             if self._data is not None and other._data is not None:
@@ -207,17 +199,7 @@ class FiberRows(Header, PositionTable):
             return img
 
         elif isinstance(other, numpy.ndarray):
-            img = self.__class__(
-                error=self._error,
-                mask=self._mask,
-                header=self._header,
-                shape=self._shape,
-                size=self._size,
-                arc_position_x=self._arc_position_x,
-                arc_position_y=self._arc_position_y,
-                good_fibers=self._good_fibers,
-                fiber_type=self._fiber_type,
-            )
+            img = copy(self)
 
             if self._data is not None:  # check if there is data in the object
                 dim = other.shape
@@ -231,11 +213,13 @@ class FiberRows(Header, PositionTable):
                         new_data = self._data / other[numpy.newaxis, :]
                 else:
                     new_data = self._data
-                if self._error is not None:
-                    new_error = self._error / other
-                else:
-                    new_error = None
-                img.setData(data=new_data, error=new_error)
+                img.setData(data=new_data)
+
+            if self._error is not None:
+                new_error = self._error / other
+            else:
+                new_error = None
+            img.setData(error=new_error)
             return img
         else:
             # try to do addtion for other types, e.g. float, int, etc.
@@ -245,18 +229,8 @@ class FiberRows(Header, PositionTable):
                 new_error = self._error / other
             else:
                 new_error = None
-            img = self.__class__(
-                data=new_data,
-                error=new_error,
-                mask=self._mask,
-                header=self._header,
-                shape=self._shape,
-                size=self._size,
-                arc_position_x=self._arc_position_x,
-                arc_position_y=self._arc_position_y,
-                good_fibers=self._good_fibers,
-                fiber_type=self._fiber_type,
-            )
+            img = copy(self)
+            img.setData(data=new_data, error=new_error)
             return img
         # except:
         # raise exception if the type are not matching in general
@@ -383,15 +357,7 @@ class FiberRows(Header, PositionTable):
         if isinstance(other, self.__class__):
             # define behaviour if the other is of the same instance
 
-            img = self.__class__(
-                header=self._header,
-                shape=self._shape,
-                size=self._size,
-                arc_position_x=self._arc_position_x,
-                arc_position_y=self._arc_position_y,
-                good_fibers=self._good_fibers,
-                fiber_type=self._fiber_type,
-            )
+            img = copy(self)
 
             # subtract data if contained in both
             if self._data is not None and other._data is not None:
@@ -422,17 +388,7 @@ class FiberRows(Header, PositionTable):
             return img
 
         elif isinstance(other, numpy.ndarray):
-            img = self.__class__(
-                error=self._error,
-                mask=self._mask,
-                header=self._header,
-                shape=self._shape,
-                size=self._size,
-                arc_position_x=self._arc_position_x,
-                arc_position_y=self._arc_position_y,
-                good_fibers=self._good_fibers,
-                fiber_type=self._fiber_type,
-            )
+            img = copy(self)
 
             if self._data is not None:  # check if there is data in the object
                 dim = other.shape
@@ -447,6 +403,11 @@ class FiberRows(Header, PositionTable):
                 else:
                     new_data = self._data
                 img.setData(data=new_data)
+            if self._error is not None:
+                new_error = self._error * other
+            else:
+                new_error = None
+            img.setData(error=new_error)
             return img
         else:
             # try to do addtion for other types, e.g. float, int, etc.

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -734,12 +734,13 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
 
     if use_world_coords and ("ra" in slitmap.colnames and "dec" in slitmap.colnames):
         xcol, ycol = "ra", "dec"
+        pa = getattr(rss, "_header", {}).get(f"PO{telescope.upper()}PA", 0)
     else:
         xcol, ycol = "xpmm", "ypmm"
+        pa = 0
 
     sel_telescope = slitmap["telescope"].data == telescope
     x, y = slitmap[xcol].data[sel_telescope], slitmap[ycol].data[sel_telescope]
-    pa = getattr(rss, "_header", {}).get(f"PO{telescope.upper()}PA", 0)
 
     if rss is None and slitmap is not None and z is not None:
         z_ = z[sel_telescope]
@@ -747,7 +748,7 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
         z = rss.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=comb_stat, telescope=telescope)
         z_ = z[sel_telescope]
     else:
-        raise ValueError("Either `z` or `rss`, `cwave`, `dwave` and `comb_stat` have to be given")
+        raise ValueError("Either `z` and `slitmap` or `rss`, `slitmap`, `cwave`, `dwave` and `comb_stat` have to be given")
 
     if norm_z:
         z_ /= np.nanmean(z_)

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -870,7 +870,7 @@ def slit(x=None, y=None, rss=None, data=None, cwave=None, dwave=None, comb_stat=
 
     mu = np.nanmean(y)
     ax.axhline(mu, ls="--", color="0.2", lw=1)
-    ax.vlines([648, 2*648], *ax.get_ylim(), ls="--", color="0.2", lw=1)
+    ax.vlines([648, 2*648], 0, 100, ls="--", color="0.2", lw=1)
     if margins_percent:
         xmin = ax.get_xlim()[0]
         for margin in margins_percent:

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -703,11 +703,12 @@ def plot_fiber_thermal_shift(columns, column_shifts, median_shift, std_shift, ax
 
 def plot_gradient_fit(slitmap, z, gradient_model, factors_model, telescope=None, marker_size=15, labels=True, axs=None):
 
-    model = gradient_model * factors_model
     gradient_model_ = gradient_model.copy()
     gradient_model_ /= gradient_model_.mean()
     factors_model_ = factors_model.copy()
     factors_model_ /= factors_model_.mean()
+    model = gradient_model_ * factors_model_
+    model /= model.mean()
 
     if axs is None:
         _, axs = plt.subplots(1, 5, figsize=(15, 4), sharex=True, sharey=True, layout="constrained")
@@ -715,6 +716,23 @@ def plot_gradient_fit(slitmap, z, gradient_model, factors_model, telescope=None,
         titles = ["Factors", "Gradient model", "Original image", "Factor-corrected image", "Fully corrected image"]
         [axs[i].set_title(titles[i], loc="left", fontsize="large") for i, ax in enumerate(axs)]
     ifus = [factors_model_, gradient_model_, z, z/factors_model_, z/model]
+    for i in range(len(ifus)):
+        ifu_view(slitmap, z=ifus[i], telescope=telescope, ax=axs[i], marker_size=marker_size)
+
+    return axs
+
+
+def plot_radial_gradient_fit(slitmap, z, gradient_model, telescope=None, marker_size=15, labels=True, axs=None):
+
+    gradient_model_ = gradient_model.copy()
+    gradient_model_ /= gradient_model_.mean()
+
+    if axs is None:
+        _, axs = plt.subplots(1, 3, figsize=(15, 4), sharex=True, sharey=True, layout="constrained")
+    if labels:
+        titles = ["Gradient model", "Original image", "Corrected image"]
+        [axs[i].set_title(titles[i], loc="left", fontsize="large") for i, ax in enumerate(axs)]
+    ifus = [gradient_model_, z, z/gradient_model_]
     for i in range(len(ifus)):
         ifu_view(slitmap, z=ifus[i], telescope=telescope, ax=axs[i], marker_size=marker_size)
 
@@ -802,6 +820,7 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
     norm = simple_norm(z_[~np.isnan(z_)], **nminmax)
     sc = ax.scatter(x_, y_, c=z_, s=marker_size, marker=(6, 0, 90-pa), norm=norm, cmap=cmap)
     set_colorbar(ax, sc)
+    ax.set_aspect("equal")
 
     if hide_axis:
         ax.set_frame_on(False)

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -721,7 +721,7 @@ def plot_gradient_fit(slitmap, z, gradient_model, factors_model, telescope=None,
     return axs
 
 
-def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=None, telescope="Sci",
+def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=None, telescope="Sci", use_world_coords=False,
              marker_size=50, norm_z=True, norm_cuts=None, norm_percents=None, cmap="coolwarm",
              hide_axis=True, ax=None, return_xyz=False):
 
@@ -732,7 +732,7 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
     if slitmap is None:
         raise ValueError("Either `slitmap` or `rss._slitmap` have to be given")
 
-    if "ra" in slitmap.colnames and "dec" in slitmap.colnames:
+    if use_world_coords and ("ra" in slitmap.colnames and "dec" in slitmap.colnames):
         xcol, ycol = "ra", "dec"
     else:
         xcol, ycol = "xpmm", "ypmm"

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -740,7 +740,8 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
         pa = 0
 
     sel_telescope = slitmap["telescope"].data == telescope
-    x, y = slitmap[xcol].data[sel_telescope], slitmap[ycol].data[sel_telescope]
+    x, y = slitmap[xcol].data, slitmap[ycol].data
+    x_, y_ = x[sel_telescope], y[sel_telescope]
 
     if rss is None and slitmap is not None and z is not None:
         z_ = z[sel_telescope]
@@ -763,7 +764,7 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
     if ax is None:
         fig, ax = plt.subplots(figsize=(5, 5), layout="constrained")
     norm = simple_norm(z_[~np.isnan(z_)], **nminmax)
-    sc = ax.scatter(x, y, c=z_, s=marker_size, marker=(6, 0, 90-pa), norm=norm, cmap=cmap)
+    sc = ax.scatter(x_, y_, c=z_, s=marker_size, marker=(6, 0, 90-pa), norm=norm, cmap=cmap)
     set_colorbar(ax, sc)
 
     if hide_axis:

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -739,7 +739,7 @@ def plot_radial_gradient_fit(slitmap, z, gradient_model, telescope=None, marker_
     return axs
 
 
-def plot_flatfield_validation(fframe, cwaves, dwave=8, coadd_method="integrate", labels=True, axs=None):
+def plot_flatfield_validation(fframe, cwaves, dwave=8, coadd_method="average", labels=True, axs=None):
 
     if axs is None:
         _, axs = plt.subplots(1, len(cwaves), figsize=(4*len(cwaves),4), sharex=True, sharey=True, layout="constrained")
@@ -747,7 +747,7 @@ def plot_flatfield_validation(fframe, cwaves, dwave=8, coadd_method="integrate",
     cwaves = np.atleast_1d(cwaves)
     for i, ax in enumerate(axs):
         if coadd_method == "average":
-            z, y, y = fframe.coadd_flux(cwave=cwaves[i], dwave=dwave, comb_stat=bn.nanmedian, return_xy=True)
+            z, y, y = fframe.coadd_flux(cwave=cwaves[i], dwave=dwave, comb_stat=bn.nanmean, return_xy=True)
         elif coadd_method == "integrate":
             z, y, y = fframe.coadd_flux(cwave=cwaves[i], dwave=dwave, comb_stat=lambda a, axis: np.trapz(np.nan_to_num(a, nan=0), fframe._wave, axis=axis), return_xy=True)
         elif coadd_method == "fit":

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -813,7 +813,7 @@ def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=N
 
 
 def slit(x=None, y=None, rss=None, cwave=None, dwave=None, comb_stat=None, telescope=None,
-         norm_stat=np.nanmean, margins_percent=[1,2,5], ax=None, return_xy=True):
+         norm_stat=np.nanmean, margins_percent=[1,2,5], style="-", color="tab:blue", label=None, ax=None, return_xy=True):
 
     if rss is None and y is not None:
         pass
@@ -829,9 +829,9 @@ def slit(x=None, y=None, rss=None, cwave=None, dwave=None, comb_stat=None, teles
         y /= norm_stat(y)
 
     if ax is None:
-        _, ax = create_subplots(figsize=(15,5), layout="constrained")
+        _, ax = plt.subplots(figsize=(14,5), layout="constrained")
 
-    ax.plot(x, y, "-", lw=1, color="tab:blue")
+    ax.plot(x, y, style, lw=1, color=color, label=label)
 
     mu = np.nanmean(y)
     ax.axhline(mu, ls="--", color="0.2", lw=1)

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -721,6 +721,42 @@ def plot_gradient_fit(slitmap, z, gradient_model, factors_model, telescope=None,
     return axs
 
 
+def plot_flat_consistency(fflats, mflat, spec_wise=False, log_scale=False, labels=False, axs=None):
+
+    if axs is None:
+        fig, axs = plt.subplots(2, int(np.ceil(len(fflats)/2)), figsize=(14,5), sharex=True, sharey=True, layout="constrained")
+        axs = axs.ravel()
+    else:
+        fig = plt.gcf()
+
+    if labels:
+        fig.supxlabel("master / individual flat field", fontsize="large")
+        fig.supylabel("Frequency", fontsize="large")
+        [axs[i].set_title(f"{fflat._header['EXPOSURE']}", loc="left", fontsize="small") for i, fflat in enumerate(fflats)]
+
+    if log_scale:
+        plt.yscale("log")
+
+    for ax in axs:
+        ax.tick_params(labelsize="x-small")
+
+    for i, flat in enumerate(fflats):
+        if spec_wise:
+            labels_ = ["sp1", "sp2", "sp3"] if i==0 else None
+            colors = ["tab:blue", "tab:red", "tab:green"]
+            data = np.split((mflat._data / flat._data), 3, axis=0)
+            data = [d.ravel() for d in data]
+            axs[i].hist(data, bins=1000, range=(0.98, 1.02), stacked=True, label=labels_, color=colors, alpha=0.5, lw=0)
+        else:
+            data = (mflat._data / flat._data).ravel()
+            axs[i].hist(data, bins=1000, range=(0.98, 1.02))
+        axs[i].axvspan(0.99, 1.01, lw=0, color="0.2", alpha=0.2, zorder=9)
+    if spec_wise:
+        axs[0].legend(loc=1, frameon=False, fontsize="small")
+
+    return axs
+
+
 def ifu_view(slitmap=None, z=None, rss=None, cwave=None, dwave=None, comb_stat=None, telescope="Sci", use_world_coords=False,
              marker_size=50, norm_z=True, norm_cuts=None, norm_percents=None, cmap="coolwarm",
              hide_axis=True, ax=None, return_xyz=False):

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3266,9 +3266,7 @@ class RSS(FiberRows):
             return flux_slit.squeeze(), rss._slitmap["xpmm"].data, rss._slitmap["ypmm"].data
         return flux_slit.squeeze()
 
-    def fit_ifu_gradient(self, cwave, dwave=8, groupby="spec", coadd_method="average", axs=None):
-
-        fiber_groups = self._get_fiber_groups(groupby)
+    def fit_ifu_gradient(self, cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec", coadd_method="average", axs=None):
 
         if coadd_method == "average":
             z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, return_xy=True, telescope="Sci")
@@ -3278,9 +3276,9 @@ class RSS(FiberRows):
         z_ = z / mu
 
         # # define guess and boundary values
-        guess_coeffs = [1, 2, 3, 0]
+        fiber_groups = self._get_fiber_groups(groupby)
         guess_factors = len(set(fiber_groups)) * [1]
-        model = IFUGradient(guess_coeffs, guess_factors, fixed_coeffs=[3])
+        model = IFUGradient(guess_coeffs, guess_factors, fixed_coeffs=fixed_coeffs)
 
         mask = numpy.isfinite(z_)
         model.fit(x[mask], y[mask], z_[mask], fiber_groups[mask])

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3082,9 +3082,12 @@ class RSS(FiberRows):
             select_tel = self._slitmap["telescope"] == telescope
         else:
             select_tel = numpy.ones_like(data.size, dtype="bool")
+
+        data[~select_tel] = numpy.nan
+
         if return_xy:
-            return data[select_tel], self._slitmap["xpmm"].data[select_tel], self._slitmap["ypmm"].data[select_tel]
-        return data[select_tel]
+            return data, self._slitmap["xpmm"].data, self._slitmap["ypmm"].data
+        return data
 
     def get_helio_rv(self, apply_hrv_corr=False):
         """Calculates heliocentric velocity corrections for each telescope and standard fiber

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3269,12 +3269,15 @@ class RSS(FiberRows):
 
     def fit_ifu_gradient(self, cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec", coadd_method="integrate", axs=None):
 
-        if coadd_method == "integrate":
+        if coadd_method == "average":
+            z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=bn.nanmedian, return_xy=True, telescope="Sci")
+        elif coadd_method == "integrate":
             z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=lambda a, axis: numpy.trapz(numpy.nan_to_num(a, nan=0), self._wave, axis=axis), return_xy=True, telescope="Sci")
         elif coadd_method == "fit":
             z, x, y = self.fit_lines_slit(cwaves=cwave, return_xy=True, select_fibers="Sci")
         else:
             raise ValueError(f"Invalid value for `coadd_method`: {coadd_method}. Expected either 'fit' or 'integrate'")
+
         mu = numpy.nanmean(z)
         z_ = z / mu
 

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3267,16 +3267,16 @@ class RSS(FiberRows):
             return flux_slit.squeeze(), rss._slitmap["xpmm"].data, rss._slitmap["ypmm"].data
         return flux_slit.squeeze()
 
-    def fit_ifu_gradient(self, cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec", coadd_method="integrate", axs=None):
+    def fit_ifu_gradient(self, cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec", coadd_method="average", axs=None):
 
         if coadd_method == "average":
-            z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=bn.nanmedian, return_xy=True, telescope="Sci")
+            z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=bn.nanmean, return_xy=True, telescope="Sci")
         elif coadd_method == "integrate":
             z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=lambda a, axis: numpy.trapz(numpy.nan_to_num(a, nan=0), self._wave, axis=axis), return_xy=True, telescope="Sci")
         elif coadd_method == "fit":
             z, x, y = self.fit_lines_slit(cwaves=cwave, return_xy=True, select_fibers="Sci")
         else:
-            raise ValueError(f"Invalid value for `coadd_method`: {coadd_method}. Expected either 'fit' or 'integrate'")
+            raise ValueError(f"Invalid value for `coadd_method`: {coadd_method}. Expected either 'average', 'integrate' or 'fit'")
 
         mu = numpy.nanmean(z)
         z_ = z / mu

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -1433,7 +1433,7 @@ class RSS(FiberRows):
 
         return self
 
-    def combineRSS(self, rsss, method="mean"):
+    def combineRSS(self, rsss, method="mean", quantile=50):
         dim = rsss[0]._data.shape
         data = numpy.zeros((len(rsss), dim[0], dim[1]), dtype=numpy.float32)
         if rsss[0]._mask is not None:
@@ -1469,6 +1469,7 @@ class RSS(FiberRows):
             "sum": lambda a, axis: bn.nansum(a, axis) if a is not None else None,
             "mean": lambda a, axis: bn.nanmean(a, axis) if a is not None else None,
             "median": lambda a, axis: bn.nanmedian(a, axis) if a is not None else None,
+            "quantile": lambda a, axis: numpy.nanpercentile(a, quantile, axis) if a is not None else None,
             "weighted_mean": lambda a, axis: bn.nansum(a * weights, axis) if a is not None else None,
             "biweight": lambda a, axis: biweight_location(a, axis=axis, ignore_nan=True) if a is not None else None,
         }
@@ -1479,7 +1480,7 @@ class RSS(FiberRows):
 
         combined_data = comb_function(data, 0)
         combined_sky = comb_function(sky, 0)
-        combined_mask = numpy.logical_or.reduce(mask, 0) if mask is not None else None
+        combined_mask = numpy.logical_and.reduce(mask, 0) if mask is not None else None
         combined_error = comb_function(error**2, 0)
         if combined_error is not None:
             combined_error = numpy.sqrt(combined_error)

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -3847,7 +3847,7 @@ class Spectrum1D(Header):
 
         return Spectrum1D(wave=wave, data=fluxes, error=errors, lsf=fwhms, mask=masks, sky=skies, sky_error=sky_errors)
 
-    def fit_lines(self, cwaves, dwave=6, axs=None):
+    def fit_lines(self, cwaves, dwave=8, axs=None):
 
         cwaves_ = numpy.atleast_1d(cwaves)
 

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -3628,7 +3628,7 @@ class Spectrum1D(Header):
                 select_2 = (self._wave>=cent[i]-3.5*fwhm[i]/2.354) & (self._wave<=cent[i]+3.5*fwhm[i]/2.354)
                 x = self._wave[select_2]
                 axs[i].axvspan(x[0], x[-1], alpha=0.1, fc="0.5", label="reg. of masking")
-                axs[i].plot(self._wave[select], self._mask[select]*numpy.nanmin(self._data[select]), "ok")
+                axs[i].plot(self._wave, (select)*numpy.nan+bn.nanmin(data), "ok")
                 axs[i] = gauss.plot(self._wave[select], self._data[select], mask=self._mask[select], ax=axs[i])
                 axs[i].axhline(bg[i], ls="--", color="tab:blue", lw=1)
                 axs[i].axvline(cent_guess[i], ls="--", lw=1, color="tab:red", label="cent. guess")

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -3637,11 +3637,13 @@ class Spectrum1D(Header):
             if axs is not None:
                 axs[i].axvspan(x[0], x[-1], alpha=0.1, fc="0.5", label="reg. of masking")
                 axs[i] = gauss.plot(self._wave[select], self._data[select], mask=self._mask[select], ax=axs[i])
+                axs[i].axhline(bg[i], ls="--", color="tab:blue", lw=1)
                 axs[i].axvline(cent_guess[i], ls="--", lw=1, color="tab:red", label="cent. guess")
                 axs[i].set_title(f"{axs[i].get_title()} @ {cent[i]:.1f} (pixel)")
                 axs[i].text(0.05, 0.9, f"flux = {flux[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].text(0.05, 0.8, f"cent = {cent[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].text(0.05, 0.7, f"fwhm = {fwhm[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
+                axs[i].text(0.05, 0.6, f"bg   = {bg[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].legend(loc="upper right", frameon=False, fontsize=11)
 
         return flux, cent, fwhm, bg

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import warnings
 
 import numpy
 import bottleneck as bn
@@ -10,7 +11,6 @@ from scipy import signal, interpolate, ndimage, sparse
 from scipy.ndimage import zoom, median_filter
 from typing import List, Tuple
 
-from lvmdrp import log
 from lvmdrp.utils import gaussian
 from lvmdrp.core import fit_profile
 from lvmdrp.core import plot
@@ -3591,8 +3591,8 @@ class Spectrum1D(Header):
             select = (self._wave >= centre - hw) & (self._wave <= centre + hw)
             # print(i, centre, self._wave.min(), self._wave.max(), select.sum())
             if mask[select].sum() >= badpix_threshold:
-                log.warning(f"skipping line at pixel {centre} with {mask[select].sum()} >= {badpix_threshold = } bad pixels")
-                self.add_header_comment(f"skipping line at pixel {centre} with {mask[select].sum()} >= {badpix_threshold = } bad pixels")
+                warnings.warn(f"skipping line @ {centre:.2f} with {mask[select].sum()} >= {badpix_threshold = } bad pixels")
+                self.add_header_comment(f"skipping line @ {centre:.2f} with {mask[select].sum()} >= {badpix_threshold = } bad pixels")
                 continue
 
             flux_guess = numpy.interp(centre, self._wave[select], data[select]) * fact * fwhm_guess / 2.354
@@ -3624,27 +3624,31 @@ class Spectrum1D(Header):
                 flux[i], cent[i], fwhm[i] = gauss.getPar()
             fwhm[i] *= 2.354
 
-            # mask line if >=2 pixels are masked within 3.5sigma
-            model_badpix = data[select] == 0
-            x = self._wave[select].copy()
-            if not numpy.isnan([cent[i], fwhm[i]]).any():
+            if axs is not None:
                 select_2 = (self._wave>=cent[i]-3.5*fwhm[i]/2.354) & (self._wave<=cent[i]+3.5*fwhm[i]/2.354)
                 x = self._wave[select_2]
-                model_badpix = mask[select_2]
-                if model_badpix.sum() >= 2:
-                    flux[i] = cent[i] = fwhm[i] = bg[i] = numpy.nan
-
-            if axs is not None:
                 axs[i].axvspan(x[0], x[-1], alpha=0.1, fc="0.5", label="reg. of masking")
+                axs[i].plot(self._wave[select], self._mask[select]*numpy.nanmin(self._data[select]), "ok")
                 axs[i] = gauss.plot(self._wave[select], self._data[select], mask=self._mask[select], ax=axs[i])
                 axs[i].axhline(bg[i], ls="--", color="tab:blue", lw=1)
                 axs[i].axvline(cent_guess[i], ls="--", lw=1, color="tab:red", label="cent. guess")
-                axs[i].set_title(f"{axs[i].get_title()} @ {cent[i]:.1f} (pixel)")
+                axs[i].axvline(cent[i], ls="--", lw=1, color="tab:blue", label="cent. model")
+                axs[i].set_title(f"{axs[i].get_title()} @ {cent[i]:.1f} {'Angstroms' if self._pixels[0]!=self._wave[0] else 'pixels'}")
                 axs[i].text(0.05, 0.9, f"flux = {flux[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].text(0.05, 0.8, f"cent = {cent[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].text(0.05, 0.7, f"fwhm = {fwhm[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].text(0.05, 0.6, f"bg   = {bg[i]:.2f}", va="bottom", ha="left", transform=axs[i].transAxes, fontsize=11)
                 axs[i].legend(loc="upper right", frameon=False, fontsize=11)
+
+            # mask line if >=2 pixels are masked within 3.5sigma
+            model_badpix = data[select] == 0
+            if not numpy.isnan([cent[i], fwhm[i]]).any():
+                select_2 = (self._wave>=cent[i]-3.5*fwhm[i]/2.354) & (self._wave<=cent[i]+3.5*fwhm[i]/2.354)
+                model_badpix = mask[select_2]
+                if model_badpix.sum() >= 2:
+                    warnings.warn(f"masking line @ {centre:.2f} with >= 2 masked pixels within a 3.5 sigma window")
+                    self.add_header_comment(f"masking line @ {centre:.2f} with >= 2 masked pixels within a 3.5 sigma window")
+                    flux[i] = cent[i] = fwhm[i] = bg[i] = numpy.nan
 
         return flux, cent, fwhm, bg
 
@@ -3862,7 +3866,7 @@ class Spectrum1D(Header):
                                                     fwhm_guess, 0.0,
                                                     [0, numpy.inf],
                                                     [-2.5, 2.5],
-                                                    [fwhm_guess - 1.5, fwhm_guess + 1.5],
+                                                    [max(fwhm_guess - 1.5, 0), fwhm_guess + 1.5],
                                                     [0.0, numpy.inf],
                                                     axs=axs)
         return flux, sky_wave, fwhm, bg

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -3648,7 +3648,6 @@ class Spectrum1D(Header):
 
         return flux, cent, fwhm, bg
 
-
     def obtainGaussFluxPeaks(self, pos, sigma, replace_error=1e10, plot=False):
         """returns Gaussian peaks parameters, flux error and mask
 
@@ -3847,3 +3846,23 @@ class Spectrum1D(Header):
         masks = numpy.logical_or(masks, numpy.isnan(sky_errors))
 
         return Spectrum1D(wave=wave, data=fluxes, error=errors, lsf=fwhms, mask=masks, sky=skies, sky_error=sky_errors)
+
+    def fit_lines(self, cwaves, dwave=6, axs=None):
+
+        cwaves_ = numpy.atleast_1d(cwaves)
+
+        if self._lsf is None:
+            fwhm_guess = 2.5
+        else:
+            fwhm_guess = numpy.nanmean(numpy.interp(cwaves_, self._wave, self._lsf))
+
+        if axs is not None:
+            axs = numpy.atleast_1d(axs)
+        flux, sky_wave, fwhm, bg = self.fitSepGauss(cwaves_, dwave,
+                                                    fwhm_guess, 0.0,
+                                                    [0, numpy.inf],
+                                                    [-2.5, 2.5],
+                                                    [fwhm_guess - 1.5, fwhm_guess + 1.5],
+                                                    [0.0, numpy.inf],
+                                                    axs=axs)
+        return flux, sky_wave, fwhm, bg

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -22,7 +22,7 @@ from numpy import polynomial
 from scipy import interpolate, ndimage
 
 from lvmdrp.utils.decorators import skip_on_missing_input_path, skip_if_drpqual_flags
-from lvmdrp.core.constants import CONFIG_PATH, ARC_LAMPS
+from lvmdrp.core.constants import CONFIG_PATH, ARC_LAMPS, REF_SKYLINES
 from lvmdrp.core.cube import Cube
 from lvmdrp.core.tracemask import TraceMask
 from lvmdrp.core.image import loadImage
@@ -56,10 +56,6 @@ __all__ = [
 DONE_PASS = "gi"
 DONE_MAGS = numpy.asarray([22, 21])
 DONE_LIMS = numpy.asarray([1.7, 5.0])
-
-# GB hand picked isolated bright lines across each channel which are not doublest in UVES atlas
-# true wavelengths taken from UVES sky line atlas
-REF_SKYLINES = {'b':[5577.346680], 'r':[6363.782715, 7358.680176, 7392.209961], 'z':[8399.175781, 8988.383789, 9552.546875, 9719.838867]}
 
 
 def _linear_model(pars, xdata):

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1472,8 +1472,8 @@ def create_dome_fiberflats(mjd, expnums_ldls, expnums_qrtz, use_longterm_cals=Tr
 def create_twilight_fiberflats(mjd: int, use_longterm_cals: bool = True, expnums: List[int] = None,
                       ref_kind: Union[int, Callable[[np.ndarray, int], np.ndarray]] = bn.nanmedian,
                       groupby: str = "spec", guess_coeffs: List[int] = [1,0,0,0], fixed_coeffs: List[int] = [0,1,2,3],
-                      cnorms: Dict[str, float] = SKYLINES_FIBERFLAT, dwave: float = 8.0,
-                      smoothing: float = 0.2,
+                      cnorms: Dict[str, float] = SKYLINES_FIBERFLAT, dwave: float = 20.0,
+                      smoothing: float = 0.0,
                       interpolate_invalid: bool = True,
                       kind: str = "longterm",
                       skip_done: bool = False,
@@ -1504,9 +1504,9 @@ def create_twilight_fiberflats(mjd: int, use_longterm_cals: bool = True, expnums
     cnorms : dict, optional
         Dictionary of normalization wavelengths per channel. Defaults to SKYLINES_FIBERFLAT.
     dwave : float, optional
-        Width of the wavelength window for normalization. Defaults to 8.0.
+        Width of the wavelength window for normalization. Defaults to 20.0.
     smoothing : float, optional
-        Smoothing parameter for fiberflat fitting. Defaults to 0.2.
+        Smoothing parameter for fiberflat fitting. Defaults to 0.0.
     interpolate_invalid : bool, optional
         Interpolate over invalid/masked fibers. Defaults to True.
     kind : str, optional
@@ -1586,11 +1586,14 @@ def create_twilight_fiberflats(mjd: int, use_longterm_cals: bool = True, expnums
             # fit fiber throughput
             fit_fiberflat(in_rss=hflat_path, out_flat=fflat_path, out_rss=fflat_flatfielded_path,
                           ref_kind=ref_kind, groupby=groupby, guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs,
-                          norm_cwave=cnorms[channel], smoothing=smoothing, interpolate_invalid=interpolate_invalid,
+                          norm_cwave=cnorms[channel], norm_dwave=dwave, smoothing=smoothing, interpolate_invalid=interpolate_invalid,
                           display_plots=display_plots)
 
         # combine individual fiberflats into master fiberflat
-        mflat_path = path.full("lvm_master", drpver=drpver, tileid=tileid, mjd=mjd, kind="mfiberflat_twilight", camera=channel)
+        if kind == "longterm":
+            mflat_path = path.full("lvm_master", drpver=drpver, tileid=tileid, mjd=mjd, kind="mfiberflat_twilight", camera=channel)
+        else:
+            mflat_path = path.full("lvm_master", drpver=drpver, tileid=tileid, mjd=mjd, kind="nfiberflat_twilight", camera=channel)
         combine_twilight_sequence(
             in_twilights=xtwi_paths,
             in_fflats=fflat_paths, out_mflat=mflat_path, out_lvmflats=lvmflat_paths,

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1471,7 +1471,7 @@ def create_dome_fiberflats(mjd, expnums_ldls, expnums_qrtz, use_longterm_cals=Tr
 
 def create_twilight_fiberflats(mjd: int, use_longterm_cals: bool = True, expnums: List[int] = None,
                       ref_kind: Union[int, Callable[[np.ndarray, int], np.ndarray]] = bn.nanmedian,
-                      groupby: str = "spec", guess_coeffs: List[int] = [1,0,0,0], fixed_coeffs: List[int] = [1,2,3],
+                      groupby: str = "spec", guess_coeffs: List[int] = [1,0,0,0], fixed_coeffs: List[int] = [0,1,2,3],
                       cnorms: Dict[str, float] = SKYLINES_FIBERFLAT, dwave: float = 8.0,
                       smoothing: float = 0.2,
                       interpolate_invalid: bool = True,

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -305,6 +305,7 @@ def combine_twilight_sequence(in_twilights: list[str], in_fflats: List[str], out
         fflat._error[select_nonexposed] = np.nan
         fflat._mask[select_nonexposed] = True
 
+    # TODO: reject outlying flat fields before combining
     log.info(f"combining {len(fflats)} individual flat fields using {comb_method = }")
     mflat = RSS()
     mflat.combineRSS(fflats, method=comb_method)
@@ -503,7 +504,9 @@ def iterate_gradient_fit(rss, cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coef
         fres, gres = np.abs(factors_residual.max() - 1), np.abs(gradient_residual.max() / gradient_residual.min() - 1)
 
         log.info(f" iteration {i+1}/{niter}")
-        log.info(f"     factors residuals  = {fres:.4f}")
+        log.info(f"                factors = {np.round(factors_residual[::rss._fibers//factors.size], 4)}")
+        log.info(f"        gradient across = {gradient_residual.max()/gradient_residual.min():.4f}")
+        log.info(f"      factors residuals = {fres:.4f}")
         log.info(f"     gradient residuals = {gres:.4f}")
         if (fthr > fres and gthr > gres) or i+1 == niter:
             break

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -1466,58 +1466,59 @@ def reduce_2d(mjd, calibrations, expnums=None, exptime=None, cameras=CAMERAS,
                                         parallel=parallel_run)
 
 
-def reduce_1d(expnum, calibrations, replace_with_nan=True, sub_straylight=True, skip_done=True, keep_ancillary=False):
+def reduce_1d(mjd, calibrations, expnums=None, replace_with_nan=True, sub_straylight=True, skip_done=True, keep_ancillary=False):
 
-    mjd = mjd_from_expnum(expnum)[0]
     frames = get_frames_metadata(mjd)
-    frames.query("expnum == @expnum", inplace=True)
-    frames.sort_values(["camera"], inplace=True)
-
-    frame = frames.iloc[0].to_dict()
+    if expnums is not None:
+        frames.query("expnum in @expnums", inplace=True)
+    frames.sort_values(["expnum", "camera"], inplace=True)
     cameras = frames.camera.unique()
 
-    for camera in cameras:
-        frame["camera"] = camera
-        if sub_straylight:
-            dframe_path = path.full("lvm_anc", drpver=drpver, kind="l", imagetype=frame["imagetyp"], **frame)
-        else:
-            dframe_path = path.full("lvm_anc", drpver=drpver, kind="d", imagetype=frame["imagetyp"], **frame)
-        xframe_path = path.full("lvm_anc", drpver=drpver, kind="x", imagetype=frame["imagetyp"], **frame)
-        os.makedirs(os.path.dirname(xframe_path), exist_ok=True)
+    for _, sci in frames.iterrows():
 
-        # define calibration frames paths
-        mtrace_path = calibrations["trace"][camera]
-        mwidth_path = calibrations["width"][camera]
-        mmodel_path = calibrations["model"][camera]
+        sci_pars = sci.to_dict()
+        for camera in cameras:
+            sci["camera"] = camera
+            if sub_straylight:
+                dframe_path = path.full("lvm_anc", drpver=drpver, kind="l", imagetype=sci["imagetyp"], **sci_pars)
+            else:
+                dframe_path = path.full("lvm_anc", drpver=drpver, kind="d", imagetype=sci["imagetyp"], **sci_pars)
+            xframe_path = path.full("lvm_anc", drpver=drpver, kind="x", imagetype=sci["imagetyp"], **sci)
+            os.makedirs(os.path.dirname(xframe_path), exist_ok=True)
 
-        # extract 1d spectra
-        if skip_done and os.path.isfile(xframe_path):
-            continue
-        else:
-            extract_spectra(in_image=dframe_path, out_rss=xframe_path, in_trace=mtrace_path, in_fwhm=mwidth_path, in_model=mmodel_path, method="optimal", parallel=1)
+            # define calibration frames paths
+            mtrace_path = calibrations["trace"][camera]
+            mwidth_path = calibrations["width"][camera]
+            mmodel_path = calibrations["model"][camera]
 
-    mwave_groups = group_calib_paths(calibrations["wave"])
-    mlsf_groups = group_calib_paths(calibrations["lsf"])
-    for channel in "brz":
-        frame["camera"] = f"{channel}[123]"
-        xframe_paths = sorted(path.expand('lvm_anc', drpver=drpver, kind='x', imagetype=frame["imagetyp"], **frame))
-        frame["camera"] = channel
-        xframe_path = path.full('lvm_anc', drpver=drpver, kind='x', imagetype=frame["imagetyp"], **frame)
-        wframe_path = path.full('lvm_anc', drpver=drpver, kind='w', imagetype=frame["imagetyp"], **frame)
-        mwave_paths = mwave_groups[channel]
-        mlsf_paths = mlsf_groups[channel]
-
-        # stack spectrographs
-        if skip_done and os.path.isfile(wframe_path):
-            continue
-        else:
-            stack_spectrographs(in_rsss=xframe_paths, out_rss=xframe_path)
-            if not os.path.exists(xframe_path):
-                log.error(f'No stacked file found: {xframe_path}. Skipping remaining pipeline.')
+            # extract 1d spectra
+            if skip_done and os.path.isfile(xframe_path):
                 continue
+            else:
+                extract_spectra(in_image=dframe_path, out_rss=xframe_path, in_trace=mtrace_path, in_fwhm=mwidth_path, in_model=mmodel_path, method="optimal", parallel=1)
 
-            # wavelength calibrate
-            create_pixel_table(in_rss=xframe_path, out_rss=wframe_path, in_waves=mwave_paths, in_lsfs=mlsf_paths)
+        mwave_groups = group_calib_paths(calibrations["wave"])
+        mlsf_groups = group_calib_paths(calibrations["lsf"])
+        for channel in "brz":
+            sci["camera"] = f"{channel}[123]"
+            xframe_paths = sorted(path.expand('lvm_anc', drpver=drpver, kind='x', imagetype=sci["imagetyp"], **sci))
+            sci["camera"] = channel
+            xframe_path = path.full('lvm_anc', drpver=drpver, kind='x', imagetype=sci["imagetyp"], **sci)
+            wframe_path = path.full('lvm_anc', drpver=drpver, kind='w', imagetype=sci["imagetyp"], **sci)
+            mwave_paths = mwave_groups[channel]
+            mlsf_paths = mlsf_groups[channel]
+
+            # stack spectrographs
+            if skip_done and os.path.isfile(wframe_path):
+                continue
+            else:
+                stack_spectrographs(in_rsss=xframe_paths, out_rss=xframe_path)
+                if not os.path.exists(xframe_path):
+                    log.error(f'No stacked file found: {xframe_path}. Skipping remaining pipeline.')
+                    continue
+
+                # wavelength calibrate
+                create_pixel_table(in_rss=xframe_path, out_rss=wframe_path, in_waves=mwave_paths, in_lsfs=mlsf_paths)
 
 
 def science_reduction(expnum: int, use_longterm_cals: bool = False,

--- a/python/lvmdrp/utils/paths.py
+++ b/python/lvmdrp/utils/paths.py
@@ -1,12 +1,14 @@
 import os
 import fnmatch
 from itertools import groupby
+import pandas as pd
 
 from typing import List, Union
 
 from lvmdrp.core.constants import CALIBRATION_NAMES, CAMERAS, MASTERS_DIR
-from lvmdrp import path
+from lvmdrp import path, __version__ as drpver
 from lvmdrp.utils.convert import tileid_grp
+from lvmdrp.utils import metadata as md
 
 
 def get_master_mjd(sci_mjd: int) -> int:
@@ -153,4 +155,47 @@ def group_calib_paths(calib_paths):
     paths = {}
     for channel, cameras in groupby(calib_paths, key=lambda p: os.path.basename(p).split(".")[0].split("-")[-1][0]):
         paths[channel] = sorted([calib_paths[camera] for camera in cameras])
+    return paths
+
+
+def get_frames_paths(mjds, kind, camera_or_channel, query=None, expnums=None, filetype="lvm_anc", drpver=drpver, filter_existing=True):
+    """Generate file paths for a set of frames based on specified parameters.
+
+    Parameters
+    ----------
+    mjds : int or list[int]
+        MJD(s) to retrieve frame metadata for. Can be a single integer or a list of integers.
+    kind : str
+        The type of path to create (e.g., 'x', 'l', 'w').
+    camera_or_channel : str
+        The camera or channel identifier (e.g., 'r1', 'b').
+    query : str, optional
+        A query string to filter the frames DataFrame. Defaults to None.
+    expnums : list[int], optional
+        A list of exposure numbers to filter the frames. If None, no filtering
+        is applied. Defaults to None.
+    filetype : str, optional
+        The type of file to generate paths for (e.g., 'lvm_anc', 'lvm_frame'). Defaults to "lvm_anc".
+    drpver : str, optional
+        The data reduction pipeline version to use. Defaults to the current version.
+    filter_existing : bool, optional
+        If True, only include paths that correspond to existing files.
+        Defaults to True.
+
+    Returns
+    -------
+    list[str]
+        A list of file paths corresponding to the specified frames and parameters.
+    """
+    mjds = [mjds] if isinstance(mjds, int) else mjds
+    frames = pd.concat([md.get_frames_metadata(mjd=mjd).query(query) for mjd in mjds], ignore_index=True)
+    if query is not None:
+        frames = frames.query(query)
+    if expnums is not None:
+        frames = frames.query("expnum in @expnums")
+
+    f = frames.drop_duplicates(subset=["expnum"])
+    paths = [path.full(filetype, mjd=s.mjd, tileid=s.tileid, drpver=drpver, kind=kind, camera=camera_or_channel, imagetype=s.imagetyp, expnum=s.expnum) for _, s in f.iterrows()]
+    if filter_existing:
+        paths = list(filter(lambda p: os.path.isfile(p), paths))
     return paths

--- a/python/lvmdrp/utils/paths.py
+++ b/python/lvmdrp/utils/paths.py
@@ -188,7 +188,7 @@ def get_frames_paths(mjds, kind, camera_or_channel, query=None, expnums=None, fi
         A list of file paths corresponding to the specified frames and parameters.
     """
     mjds = [mjds] if isinstance(mjds, int) else mjds
-    frames = pd.concat([md.get_frames_metadata(mjd=mjd).query(query) for mjd in mjds], ignore_index=True)
+    frames = pd.concat([md.get_frames_metadata(mjd=mjd) for mjd in mjds], ignore_index=True)
     if query is not None:
         frames = frames.query(query)
     if expnums is not None:


### PR DESCRIPTION
We discovered that exposures of ~ 10s can show large inconsistencies in count levels between spectrographs due to shutter timing effects. This PR aims at mitigating those effects by fitting the spectrograph-to-spectrograph flat field using sky lines in science exposures.

The main changes are:

- Implemented simultaneous IFU "linear" gradient and spec-to-spec factors fitting
- Implemented science frame spec-to-spec factors fitting
- Added/Updated CLI for current fiber flatfielding routines
- Implemented useful QA plots
- Improved/Fixed error propagation for FiberRows/RSS objects
- Bug fixes and other improvements all around

TODOs:

- Implement automatic rejection of faulty twilights from a given sequence
- Implement automatic selection of science frames for spec-to-spec factors fitting

Example QA plots:

- Individual (per exposure) fiber flat field

![image](https://github.com/user-attachments/assets/1567d8e5-9908-4a10-8950-e17491ec9fed)

-  Combination of fiber flat fields

![image](https://github.com/user-attachments/assets/bff1b1aa-e5a2-4bee-8cec-2e455b13f85c)

- Sky lines spec-to-spec factors fitting

![image](https://github.com/user-attachments/assets/3a0f7169-1553-47b7-b717-939b34adf63a)

- Final flat field quality test on science data

![image](https://github.com/user-attachments/assets/e8c7f697-7aa7-4975-bd74-07ae367550b0)

