### PR TITLE
Sensitivity curve propagation

### DIFF
--- a/python/lvmdrp/core/fit_profile.py
+++ b/python/lvmdrp/core/fit_profile.py
@@ -6,14 +6,14 @@ import itertools
 import numpy
 import bottleneck as bn
 from functools import wraps
-from functools import lru_cache
+from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 
 import astropy.io.fits as pyfits
 from astropy.modeling.functional_models import Voigt1D, Lorentz1D, Moffat1D
 from scipy import interpolate, integrate, optimize, special
-from scipy.signal import fftconvolve, convolve
+from scipy.signal import fftconvolve
 
-from lvmdrp.core.plot import plt, create_subplots, make_axes_locatable, plot_gradient_fit, plot_radial_gradient_fit
+from lvmdrp.core.plot import plt, create_subplots, plot_gradient_fit, plot_radial_gradient_fit
 
 
 fact = numpy.sqrt(2.0 * numpy.pi)

--- a/python/lvmdrp/core/image.py
+++ b/python/lvmdrp/core/image.py
@@ -2,7 +2,6 @@ from copy import deepcopy as copy
 from multiprocessing import Pool, cpu_count
 import warnings
 
-from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 from functools import partial
 from typing import List
 from tqdm import tqdm

--- a/python/lvmdrp/core/plot.py
+++ b/python/lvmdrp/core/plot.py
@@ -13,7 +13,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import bottleneck as bn
 from astropy.visualization import AsinhStretch, ImageNormalize, PercentileInterval, simple_norm
-from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 import warnings
 

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3769,20 +3769,22 @@ class lvmCFrame(lvmBaseProduct):
         sky_west = hdulist["SKY_WEST"].data
         sky_west_error = numpy.divide(1, hdulist["SKY_WEST_IVAR"].data, where=hdulist["SKY_WEST_IVAR"].data != 0, out=numpy.zeros_like(hdulist["SKY_WEST_IVAR"].data))
         sky_west_error = numpy.sqrt(sky_west_error)
+        fluxcal_std = Table.read(hdulist["FLUXCAL_STD"])
+        fluxcal_sci = Table.read(hdulist["FLUXCAL_SCI"])
         slitmap = Table.read(hdulist["SLITMAP"])
         return cls(data=data, error=error, mask=mask, header=header,
                    wave=wave, lsf=lsf,
                    sky_east=sky_east, sky_east_error=sky_east_error,
                    sky_west=sky_west, sky_west_error=sky_west_error,
-                   slitmap=slitmap)
+                   fluxcal_std=fluxcal_std, fluxcal_sci=fluxcal_sci, slitmap=slitmap)
 
     def __init__(self, data=None, error=None, mask=None, header=None, slitmap=None, wave=None, lsf=None,
-                 sky_east=None, sky_east_error=None, sky_west=None, sky_west_error=None, **kwargs):
+                 sky_east=None, sky_east_error=None, sky_west=None, sky_west_error=None, fluxcal_std=None, fluxcal_sci=None, **kwargs):
         lvmBaseProduct.__init__(self, data=data, error=error, mask=mask, header=header,
                      wave=wave, lsf=lsf,
                      sky_east=sky_east, sky_east_error=sky_east_error,
                      sky_west=sky_west, sky_west_error=sky_west_error,
-                     slitmap=slitmap)
+                     fluxcal_std=fluxcal_std, fluxcal_sci=fluxcal_sci, slitmap=slitmap)
 
         self._blueprint = dp.load_blueprint(name="lvmCFrame")
         self._template = dp.dump_template(dataproduct_bp=self._blueprint, save=False)
@@ -3826,6 +3828,8 @@ class lvmCFrame(lvmBaseProduct):
         self._template["SKY_EAST_IVAR"].data = numpy.divide(1, self._sky_east_error**2, where=self._sky_east_error != 0, out=numpy.zeros_like(self._sky_east_error))
         self._template["SKY_WEST"].data = self._sky_west
         self._template["SKY_WEST_IVAR"].data = numpy.divide(1, self._sky_west_error**2, where=self._sky_west_error != 0, out=numpy.zeros_like(self._sky_west_error))
+        self._template["FLUXCAL_STD"] = pyfits.BinTableHDU(data=self._fluxcal_std, name="FLUXCAL_STD")
+        self._template["FLUXCAL_SCI"] = pyfits.BinTableHDU(data=self._fluxcal_sci, name="FLUXCAL_SCI")
         self._template["SLITMAP"] = pyfits.BinTableHDU(data=self._slitmap, name="SLITMAP")
         self._template.verify("silentfix")
 
@@ -3852,14 +3856,18 @@ class lvmSFrame(lvmBaseProduct):
         sky = hdulist["SKY"].data
         sky_error = numpy.divide(1, hdulist["SKY_IVAR"].data, where=hdulist["SKY_IVAR"].data != 0, out=numpy.zeros_like(hdulist["SKY_IVAR"].data))
         sky_error = numpy.sqrt(sky_error)
+        fluxcal_std = Table.read(hdulist["FLUXCAL_STD"])
+        fluxcal_sci = Table.read(hdulist["FLUXCAL_SCI"])
         slitmap = Table.read(hdulist["SLITMAP"])
         return cls(data=data, error=error, mask=mask, header=header,
-                   wave=wave, lsf=lsf, sky=sky, sky_error=sky_error, slitmap=slitmap)
+                   wave=wave, lsf=lsf, sky=sky, sky_error=sky_error,
+                   fluxcal_std=fluxcal_std, fluxcal_sci=fluxcal_sci, slitmap=slitmap)
 
-    def __init__(self, data=None, error=None, mask=None, header=None, slitmap=None, wave=None, lsf=None, sky=None, sky_error=None, **kwargs):
+    def __init__(self, data=None, error=None, mask=None, header=None, slitmap=None, wave=None, lsf=None, sky=None, sky_error=None,
+                 fluxcal_std=None, fluxcal_sci=None, **kwargs):
         lvmBaseProduct.__init__(self, data=data, error=error, mask=mask, header=header,
-                     wave=wave, lsf=lsf,
-                     sky=sky, sky_error=sky_error, slitmap=slitmap)
+                     wave=wave, lsf=lsf, sky=sky, sky_error=sky_error,
+                     fluxcal_std=fluxcal_std, fluxcal_sci=fluxcal_sci, slitmap=slitmap)
 
         self._blueprint = dp.load_blueprint(name="lvmSFrame")
         self._template = dp.dump_template(dataproduct_bp=self._blueprint, save=False)
@@ -3899,6 +3907,8 @@ class lvmSFrame(lvmBaseProduct):
         self._template["LSF"].data = self._lsf
         self._template["SKY"].data = self._sky.astype("float32")
         self._template["SKY_IVAR"].data = numpy.divide(1, self._sky_error**2, where=self._sky_error != 0, out=numpy.zeros_like(self._sky_error))
+        self._template["FLUXCAL_STD"] = pyfits.BinTableHDU(data=self._fluxcal_std, name="FLUXCAL_STD")
+        self._template["FLUXCAL_SCI"] = pyfits.BinTableHDU(data=self._fluxcal_sci, name="FLUXCAL_SCI")
         self._template["SLITMAP"] = pyfits.BinTableHDU(data=self._slitmap, name="SLITMAP")
         self._template.verify("silentfix")
 

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -11,7 +11,7 @@ from astropy.table import Table
 from astropy.time import Time
 from astropy.coordinates import SkyCoord
 from astropy.coordinates import EarthLocation
-from astropy.stats import biweight_location
+from astropy.stats import biweight_location, biweight_scale
 from astropy import units as u
 
 from lvmdrp import log
@@ -366,6 +366,7 @@ class RSS(FiberRows):
         # optionally interpolate if the merged wavelengths are not monotonic
         fluxes, errors, masks, lsfs, skies, sky_errors = [], [], [], [], [], []
         skies_e, skies_w, sky_e_errors, sky_w_errors = [], [], [], []
+        fluxcals_sci, fluxcals_std = [], []
         if numpy.all(numpy.isclose(sampling, sampling[0], atol=1e-2)):
             log.info(f"current wavelength sampling: min = {sampling.min():.2f}, max = {sampling.max():.2f}")
             # extend rss._data to new_wave filling with NaNs
@@ -381,6 +382,8 @@ class RSS(FiberRows):
                 sky_e_errors.append(rss._sky_east_error)
                 skies_w.append(rss._sky_west)
                 sky_w_errors.append(rss._sky_west_error)
+                fluxcals_std.append(rss._fluxcal_std.to_pandas().values.T)
+                fluxcals_sci.append(rss._fluxcal_sci.to_pandas().values.T)
             fluxes = numpy.asarray(fluxes)
             errors = numpy.asarray(errors)
             masks = numpy.asarray(masks)
@@ -391,6 +394,8 @@ class RSS(FiberRows):
             sky_e_errors = numpy.asarray(sky_e_errors)
             skies_w = numpy.asarray(skies_w)
             sky_w_errors = numpy.asarray(sky_w_errors)
+            fluxcals_std = numpy.asarray(fluxcals_std)
+            fluxcals_sci = numpy.asarray(fluxcals_sci)
         else:
             log.error("merged wavelengths are not monotonic or uniform!")
             raise RuntimeError("merged wavelengths are not monotonic or uniform!")
@@ -452,6 +457,26 @@ class RSS(FiberRows):
                 new_skyw_error = numpy.sqrt(bn.nansum(sky_w_errors ** 2 * weights ** 2, axis=0))
             else:
                 new_skyw_error = None
+            if rss._fluxcal_std is not None:
+                std_selection = [numpy.where(rss._slitmap["orig_ifulabel"]==s)[0][0] for s in [rss._header[s[:-3]+"FIB"] for s in rss._fluxcal_std.colnames[:-2]] if s is not None]
+                w = numpy.full_like(fluxcals_std[:, :-2, :], fill_value=numpy.nan)
+                w[:, ~numpy.isnan(fluxcals_std[:, :-2, :]).all(axis=(0,2)), :] = weights[:, std_selection, :]
+                w = numpy.concatenate((w, biweight_location(w, axis=1, ignore_nan=True)[:, None, :], biweight_scale(w, axis=1, ignore_nan=True)[:, None, :]), axis=1)
+                a = bn.nansum(fluxcals_std * w, axis=0)
+                a[numpy.isnan(fluxcals_std).all(axis=(0,2)), :] = numpy.nan
+                new_fluxcal_std = Table(a.T, names=rss._fluxcal_std.colnames)
+            else:
+                new_fluxcal_std = None
+            if rss._fluxcal_sci is not None:
+                sci_selection = [numpy.where(rss._slitmap["fiberid"]==s)[0][0] for s in [rss._header.get(s[:-3]+"FIB") for s in rss._fluxcal_sci.colnames[:-2]] if s is not None]
+                w = numpy.full_like(fluxcals_sci[:, :-2, :], fill_value=numpy.nan)
+                w[:, ~numpy.isnan(fluxcals_sci[:, :-2, :]).all(axis=(0,2)), :] = weights[:, sci_selection, :]
+                w = numpy.concatenate((w, biweight_location(w, axis=1, ignore_nan=True)[:, None, :], biweight_scale(w, axis=1, ignore_nan=True)[:, None, :]), axis=1)
+                a = bn.nansum(fluxcals_sci * w, axis=0)
+                a[numpy.isnan(fluxcals_sci).all(axis=(0,2)), :] = numpy.nan
+                new_fluxcal_sci = Table(a.T, names=rss._fluxcal_sci.colnames)
+            else:
+                new_fluxcal_sci = None
         else:
             # channel-combine RSS data
             new_data = bn.nanmean(fluxes, axis=0)
@@ -481,6 +506,14 @@ class RSS(FiberRows):
                 new_skyw_error = numpy.sqrt(bn.nanmean(sky_w_errors ** 2, axis=0))
             else:
                 new_skyw_error = None
+            if rss._fluxcal_std is not None:
+                new_fluxcal_std = Table(bn.nanmean(fluxcals_std, axis=0).T, columns=rss._fluxcal_std.colnames)
+            else:
+                new_fluxcal_std = None
+            if rss._fluxcal_sci is not None:
+                new_fluxcal_sci = Table(bn.nanmean(fluxcals_sci, axis=0).T, columns=rss._fluxcal_sci.colnames)
+            else:
+                new_fluxcal_sci = None
 
         # create RSS
         new_hdr = rsss[0]._header.copy()
@@ -499,6 +532,8 @@ class RSS(FiberRows):
             sky_east_error=new_skye_error,
             sky_west=new_skyw,
             sky_west_error=new_skyw_error,
+            fluxcal_std=new_fluxcal_std,
+            fluxcal_sci=new_fluxcal_sci,
             header=new_hdr,
             slitmap=rsss[0]._slitmap
         )
@@ -1268,6 +1303,20 @@ class RSS(FiberRows):
             new_lsf[:, ipix:fpix+1] = self._lsf
         else:
             new_lsf = None
+        if self._fluxcal_std is not None:
+            fluxcal = self._fluxcal_std.to_pandas().values.T
+            new_fluxcal_std = numpy.full((fluxcal.shape[0], new_wave.size), numpy.nan, dtype=numpy.float32)
+            new_fluxcal_std[:, ipix:fpix+1] = fluxcal
+            new_fluxcal_std = Table(new_fluxcal_std.T, names=self._fluxcal_std.colnames)
+        else:
+            new_fluxcal_std = None
+        if self._fluxcal_sci is not None:
+            fluxcal = self._fluxcal_sci.to_pandas().values.T
+            new_fluxcal_sci = numpy.full((fluxcal.shape[0], new_wave.size), numpy.nan, dtype=numpy.float32)
+            new_fluxcal_sci[:, ipix:fpix+1] = fluxcal
+            new_fluxcal_sci = Table(new_fluxcal_sci.T, names=self._fluxcal_sci.colnames)
+        else:
+            new_fluxcal_sci = None
 
         # set new arrays
         self._data = new_data
@@ -1281,6 +1330,8 @@ class RSS(FiberRows):
         self._sky_error = new_sky_error
         self._lsf = new_lsf
         self._wave = new_wave
+        self._fluxcal_std = new_fluxcal_std
+        self._fluxcal_sci = new_fluxcal_sci
 
         return self
 

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import warnings
-from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 
 import numpy
 import bottleneck as bn

--- a/python/lvmdrp/core/tracemask.py
+++ b/python/lvmdrp/core/tracemask.py
@@ -3,12 +3,9 @@
 
 import os
 import numpy
-import bottleneck as bn
-from copy import deepcopy as copy
 from astropy.io import fits as pyfits
 from astropy.table import Table
 from lvmdrp.core.fiberrows import FiberRows
-from lvmdrp.core import plot
 
 
 class TraceMask(FiberRows):

--- a/python/lvmdrp/etc/dataproducts/lvmCFrame_bp.yaml
+++ b/python/lvmdrp/etc/dataproducts/lvmCFrame_bp.yaml
@@ -89,6 +89,158 @@ hdu9:
   - key: BUNIT
     comment: physical units of the array values
 hdu10:
+  name: FLUXCAL_STD
+  description: sensitivity from standard fibers in units of electron cm2 / erg
+  is_image: false
+  shape: BINARY FITS TABLE
+  columns:
+    STD1SEN:
+      name: STD1SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 1
+    STD2SEN:
+      name: STD2SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 2
+    STD3SEN:
+      name: STD3SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 3
+    STD4SEN:
+      name: STD4SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 4
+    STD5SEN:
+      name: STD5SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 5
+    STD6SEN:
+      name: STD6SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 6
+    STD7SEN:
+      name: STD7SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 7
+    STD8SEN:
+      name: STD8SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 8
+    STD9SEN:
+      name: STD9SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 9
+    STD10SEN:
+      name: STD10SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 10
+    STD11SEN:
+      name: STD11SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 11
+    STD12SEN:
+      name: STD12SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 12
+    MEAN_SENS:
+      name: MEAN_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: mean sensitivity
+    STDDEV_SENS:
+      name: STDDEV_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: standard deviation of sensitivity
+hdu11:
+  name: FLUXCAL_SCI
+  description: sensitivity in units of electron cm2 / erg from science fibers
+  is_image: false
+  shape: BINARY FITS TABLE
+  columns:
+    STD1SEN:
+      name: STD1SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 1
+    STD2SEN:
+      name: STD2SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 2
+    STD3SEN:
+      name: STD3SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 3
+    STD4SEN:
+      name: STD4SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 4
+    STD5SEN:
+      name: STD5SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 5
+    STD6SEN:
+      name: STD6SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 6
+    STD7SEN:
+      name: STD7SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 7
+    STD8SEN:
+      name: STD8SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 8
+    STD9SEN:
+      name: STD9SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 9
+    STD10SEN:
+      name: STD10SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 10
+    STD11SEN:
+      name: STD11SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 11
+    STD12SEN:
+      name: STD12SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 12
+    MEAN_SENS:
+      name: MEAN_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: mean sensitivity
+    STDDEV_SENS:
+      name: STDDEV_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: standard deviation of sensitivity
+hdu12:
   name: SLITMAP
   description: slitmap table describing fiber positions for this exposure
   is_image: false

--- a/python/lvmdrp/etc/dataproducts/lvmSFrame_bp.yaml
+++ b/python/lvmdrp/etc/dataproducts/lvmSFrame_bp.yaml
@@ -67,6 +67,158 @@ hdu7:
   is_image: true
   shape: NWAVE x NFIBER
 hdu8:
+  name: FLUXCAL_STD
+  description: sensitivity from standard fibers in units of electron cm2 / erg
+  is_image: false
+  shape: BINARY FITS TABLE
+  columns:
+    STD1SEN:
+      name: STD1SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 1
+    STD2SEN:
+      name: STD2SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 2
+    STD3SEN:
+      name: STD3SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 3
+    STD4SEN:
+      name: STD4SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 4
+    STD5SEN:
+      name: STD5SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 5
+    STD6SEN:
+      name: STD6SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 6
+    STD7SEN:
+      name: STD7SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 7
+    STD8SEN:
+      name: STD8SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 8
+    STD9SEN:
+      name: STD9SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 9
+    STD10SEN:
+      name: STD10SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 10
+    STD11SEN:
+      name: STD11SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 11
+    STD12SEN:
+      name: STD12SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 12
+    MEAN_SENS:
+      name: MEAN_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: mean sensitivity
+    STDDEV_SENS:
+      name: STDDEV_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: standard deviation of sensitivity
+hdu9:
+  name: FLUXCAL_SCI
+  description: sensitivity in units of electron cm2 / erg from science fibers
+  is_image: false
+  shape: BINARY FITS TABLE
+  columns:
+    STD1SEN:
+      name: STD1SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 1
+    STD2SEN:
+      name: STD2SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 2
+    STD3SEN:
+      name: STD3SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 3
+    STD4SEN:
+      name: STD4SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 4
+    STD5SEN:
+      name: STD5SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 5
+    STD6SEN:
+      name: STD6SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 6
+    STD7SEN:
+      name: STD7SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 7
+    STD8SEN:
+      name: STD8SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 8
+    STD9SEN:
+      name: STD9SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 9
+    STD10SEN:
+      name: STD10SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 10
+    STD11SEN:
+      name: STD11SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 11
+    STD12SEN:
+      name: STD12SEN
+      type: float32
+      unit: electron cm2 / erg
+      description: standard star 12
+    MEAN_SENS:
+      name: MEAN_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: mean sensitivity
+    STDDEV_SENS:
+      name: STDDEV_SENS
+      type: float32
+      unit: electron cm2 / erg
+      description: standard deviation of sensitivity
+hdu10:
   name: SLITMAP
   description: slitmap table describing fiber positions for this exposure
   is_image: false

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -385,10 +385,10 @@ def science_sensitivity(rss, res_sci, ext, GAIA_CACHE_DIR, NSCI_MAX=15, r_spaxel
             lvmflux = fluxcal.spec_to_LVM_flux(channel, obswave, obsflux)
             sens = fluxcal.spec_to_LVM_flux(channel, gwave, gflux) / lvmflux
             sens *= np.interp(obswave, mean_sens[channel]['wavelength'], mean_sens[channel]['sens'])
-            res_sci[f"STD{i+1}SEN"] = sens.astype(np.float32) * u.Unit("erg / (ct cm2)")
+            res_sci[f"SCI{i+1}SEN"] = sens.astype(np.float32) * u.Unit("erg / (ct cm2)")
             # reject sensitivity that yield negative instrumental magnitude
             if lvmflux <= 0:
-                res_sci[f"STD{i+1}SEN"][:] = np.nan
+                res_sci[f"SCI{i+1}SEN"][:] = np.nan
 
             mAB_std = np.round(fluxcal.spec_to_LVM_mAB(channel, gwave, gflux), 2)
             mAB_obs = np.round(fluxcal.spec_to_LVM_mAB(channel, obswave, obsflux), 2)
@@ -406,7 +406,7 @@ def science_sensitivity(rss, res_sci, ext, GAIA_CACHE_DIR, NSCI_MAX=15, r_spaxel
             if plot:
                 plt.plot(obswave, np.interp(obswave, gwave, gflux)/obsflux, '.',
                          color=colors[i%len(colors)] , markersize=2, zorder=-999)
-                plt.plot(obswave, res_sci[f"STD{i+1}SEN"], color=colors[i%len(colors)], linewidth=2)
+                plt.plot(obswave, res_sci[f"SCI{i+1}SEN"], color=colors[i%len(colors)], linewidth=2)
 
     return rss, res_sci
 
@@ -530,7 +530,7 @@ def fluxcal_sci_ifu_stars(in_rss, plot=True, GAIA_CACHE_DIR=None, NSCI_MAX=15):
     w = rss._wave
 
     # define dummy sensitivity array in (ergs/s/cm^2/A) / (e-/s/A) for standard star fibers
-    colnames = [f"STD{i}SEN" for i in range(1, NSCI_MAX + 1)]
+    colnames = [f"SCI{i}SEN" for i in range(1, NSCI_MAX + 1)]
     res_sci = Table(np.full(w.size, np.nan, dtype=list(zip(colnames, ["f8"] * len(colnames)))), units=[u.Unit("erg / (ct cm2)")]*len(colnames))
     mean_sci, rms_sci = np.full(w.size, np.nan), np.full(w.size, np.nan)
 

--- a/python/lvmdrp/functions/imageMethod.py
+++ b/python/lvmdrp/functions/imageMethod.py
@@ -43,7 +43,7 @@ from lvmdrp.core.image import (
     loadImage,
 )
 from lvmdrp.core import fit_profile as fp
-from lvmdrp.core.plot import plt, create_subplots, plot_detrend, plot_error, plot_strips, plot_image_shift, plot_fiber_thermal_shift, plot_fiber_residuals, save_fig
+from lvmdrp.core.plot import plt, create_subplots, plot_detrend, plot_error, plot_strips, plot_image_shift, plot_fiber_thermal_shift, save_fig
 from lvmdrp.core.rss import RSS
 from lvmdrp.core.spectrum1d import Spectrum1D, _spec_from_lines, _cross_match
 from lvmdrp.core.tracemask import TraceMask
@@ -4393,7 +4393,7 @@ def guess_fibers_params(in_image: str,
     # read slitmap extension
     slitmap = img.getSlitmap()
     slitmap = slitmap[slitmap["spectrographid"] == int(img._header["SPEC"][-1])]
-    bad_fibers = slitmap["fibstatus"] == 1
+    # bad_fibers = slitmap["fibstatus"] == 1
 
     # perform median filtering along the dispersion axis to clean cosmic rays
     img = img.enhance(median_box=median_box, coadd=coadd, trust_errors=True, apply_mask=False)

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -125,7 +125,7 @@ def _make_arcline_axes(display_plots, pixel, ref_lines, ifiber, unit="e-", ncols
                                layout="tight")
     fig.suptitle(f"Gaussian fitting for fiber {ifiber}")
     fig.supylabel(f"Counts ({unit}/pixel)", fontsize="x-large")
-    fig.supxlabel(f"X (pixel)", fontsize="x-large")
+    fig.supxlabel("X (pixel)", fontsize="x-large")
     for i, ax in zip(range(nlines), axs):
         ax.set_title(f"line {ref_lines[i]:.2f} (Ang)", fontsize="large")
 

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -3057,7 +3057,7 @@ def join_spec_channels(in_fframes: List[str], out_cframe: str, use_weights: bool
                        wave=new_rss._wave, lsf=new_rss._lsf,
                        sky_east=new_rss._sky_east, sky_east_error=new_rss._sky_east_error,
                        sky_west=new_rss._sky_west, sky_west_error=new_rss._sky_west_error,
-                       slitmap=new_rss._slitmap)
+                       fluxcal_std=new_rss._fluxcal_std, fluxcal_sci=new_rss._fluxcal_sci, slitmap=new_rss._slitmap)
 
     # write output RSS
     if out_cframe is not None:

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1418,8 +1418,8 @@ def create_traces(mjd, cameras=CAMERAS, expnums_ldls=None, expnums_qrtz=None,
         }
 
         expnums = expnums_qrtz if camera[0] == "z" else expnums_ldls
-        select_lamp = MASTER_CON_LAMPS[camera[0]]
-        counts_threshold = counts_thresholds[select_lamp]
+        # select_lamp = MASTER_CON_LAMPS[camera[0]]
+        # counts_threshold = counts_thresholds[select_lamp]
 
         # first fibers fitting (guess using pure Gaussian profiles) using first exposure in sequence
         dflat_path = path.full("lvm_anc", drpver=drpver, tileid=11111, mjd=mjd, kind="d", imagetype="flat", camera=camera, expnum=expnums[0])
@@ -1492,8 +1492,8 @@ def create_traces(mjd, cameras=CAMERAS, expnums_ldls=None, expnums_qrtz=None,
 
         # store final model and ratio
         model = image_tasks.combineImages(images=models, method="sum", normalize=False, background_subtract=False, replace_with_nan=False)
-        model.writeFitsData(path.full("lvm_master", drpver=drpver, tileid=11111, mjd=mjd, camera=camera, kind=f"mmodel"))
-        (model / img).writeFitsData(path.full("lvm_master", drpver=drpver, tileid=11111, mjd=mjd, camera=camera, kind=f"mratio"))
+        model.writeFitsData(path.full("lvm_master", drpver=drpver, tileid=11111, mjd=mjd, camera=camera, kind="mmodel"))
+        (model / img).writeFitsData(path.full("lvm_master", drpver=drpver, tileid=11111, mjd=mjd, camera=camera, kind="mratio"))
 
 
 def create_dome_fiberflats(mjd, expnums_ldls=None, expnums_qrtz=None, cals_mjd=None, use_longterm_cals=True, kind="longterm", skip_done=True, dry_run=False):

--- a/python/lvmdrp/functions/skyMethod.py
+++ b/python/lvmdrp/functions/skyMethod.py
@@ -1641,7 +1641,9 @@ def quick_sky_subtraction(in_cframe, out_sframe, skymethod: str = 'farlines_near
     # print("writing lvmSFrame")
     log.info(f"writing lvmSframe to {out_sframe}")
     sframe = lvmSFrame(data=skysub_data, error=skysub_error, mask=cframe._mask.astype(bool), sky=skydata, sky_error=sky_error,
-                       wave=cframe._wave, lsf=cframe._lsf, header=cframe._header, slitmap=cframe._slitmap)
+                       wave=cframe._wave, lsf=cframe._lsf, header=cframe._header,
+                       fluxcal_std=cframe._fluxcal_std, fluxcal_sci=cframe._fluxcal_sci,
+                       slitmap=cframe._slitmap)
     sframe._mask |= ~np.isfinite(sframe._error)
     sframe.writeFitsData(out_sframe)
     # TODO: check on expnum=7632 for halpha emission in sky fibers


### PR DESCRIPTION
Implements sensitivity curves propagations as extensions from lvmFFrames downstream to lvmSFrame. Main changes are:

- Implements spectrograph channel combine of sensitivity curves using the same weighing schema used for RSS
- Implements flux calibration swapping method to seamlessly change from standard to science field stars calibrations
- Implements propagation of sensitivity curve extensions from lvmFFrame to lvmSFrame products