### PR TITLE
Refactor and consolidate Gaia routines with improved caching

### DIFF
--- a/bin/drp
+++ b/bin/drp
@@ -14,7 +14,7 @@ from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
 
 from lvmdrp.core.constants import CALIBRATION_MAPPINGS, CALIBRATION_TYPES, LVM_REFERENCE_COLUMN
 from lvmdrp import __version__ as drpver
-from lvmdrp.main import run_drp, reduce_file, check_daily_mjd, parse_mjds, read_expfile, create_drpall, cache_gaia_spectra
+from lvmdrp.main import run_drp, reduce_file, check_daily_mjd, parse_mjds, read_expfile, create_drpall, cache_std_xp_spectra, cache_sci_xp_spectra
 from lvmdrp.functions.skyMethod import configureSkyModel_drp
 from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
 from lvmdrp.utils.cluster import run_cluster, run_cluster_cals
@@ -671,16 +671,26 @@ def summary(drp_version, overwrite):
     create_drpall(drp_version=drp_version, overwrite=overwrite)
 
 
+@cli.command(short_help='Caches Gaia XP spectra for flux calibration based on standard stars')
+@click.option('-m', '--mjd', type=int, help='an MJD to reduce')
+@click.option('-l', '--mjd-list', type=int, multiple=True, help='a list of specific MJDs to reduce')
+@click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
+@click.option('--dry-run', is_flag=True, default=False)
+@click.option("--ignore-cache", is_flag=True, default=False)
+def cache_std_xp(mjd, mjd_list, mjd_range, ignore_cache, dry_run):
+    """Caches Gaia XP spectra for flux calibration based on standard stars"""
+    cache_std_xp_spectra(mjds=mjd or mjd_list or mjd_range, ignore_cache=ignore_cache, dry_run=dry_run)
+
 @cli.command(short_help='Caches Gaia XP spectra for science field calibration')
 @click.option('-m', '--mjd', type=int, help='an MJD to reduce')
 @click.option('-l', '--mjd-list', type=int, multiple=True, help='a list of specific MJDs to reduce')
 @click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
 @click.option("--min-acquired", type=int, default=999, help='minimum number of standard stars acquired to skip caching')
+@click.option("--ignore-cache", is_flag=True, default=False)
 @click.option('--dry-run', is_flag=True, default=False)
-def cache_gaia_xp(mjd, mjd_list, mjd_range, min_acquired, dry_run):
+def cache_sci_xp(mjd, mjd_list, mjd_range, min_acquired, ignore_cache, dry_run):
     """"Caches Gaia XP spectra for science field calbration"""
-    mjds = mjd or mjd_list or mjd_range
-    cache_gaia_spectra(mjds=mjds, dry_run=dry_run, min_acquired=min_acquired)
+    cache_sci_xp_spectra(mjds=mjd or mjd_list or mjd_range, min_acquired=min_acquired, ignore_cache=ignore_cache, dry_run=dry_run)
 
 
 if __name__ == "__main__":

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -12,11 +12,9 @@ from contextlib import redirect_stdout
 from scipy import signal
 from scipy.integrate import simpson
 from scipy import interpolate
-import requests
 import pandas as pd
 import bottleneck as bn
 import os.path as path
-import pathlib
 from tqdm import tqdm
 
 import pyvo as vo
@@ -81,46 +79,6 @@ class GaiaStarNotFound(Exception):
     """
 
     pass
-
-
-def retrive_gaia_star(gaiaID, GAIA_CACHE_DIR, ignore_cache=False):
-    """
-    Load or download and load from cache the XP spectrum of a gaia star, converted to erg/s/cm^2/A
-    """
-    # create cache dir if it does not exist
-    pathlib.Path(GAIA_CACHE_DIR).mkdir(parents=True, exist_ok=True)
-
-    if not ignore_cache and path.exists(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv") is True:
-        # read the tables from our cache
-        gaiaflux = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv", format="csv")
-        gaiawave = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + "_sampling.csv", format="csv")
-    else:
-        # need to download from Gaia archive
-        CSV_URL = ("https://gea.esac.esa.int/data-server/data?RETRIEVAL_TYPE=XP_CONTINUOUS&ID=Gaia+DR3+"
-            + str(gaiaID)
-            + "&format=CSV&DATA_STRUCTURE=RAW")
-        FILE = GAIA_CACHE_DIR + "/XP_" + str(gaiaID) + "_RAW.csv"
-
-        with requests.get(CSV_URL, stream=True) as r:
-            r.raise_for_status()
-            if len(r.content) < 2:
-                raise GaiaStarNotFound(f"Gaia DR3 {gaiaID} has no BP-RP spectrum!")
-            with open(FILE, "w") as f:
-                f.write(r.content.decode("utf-8"))
-
-        # convert coefficients to sampled spectrum
-        with open(os.devnull, 'w') as f, redirect_stdout(f):
-            gaiaxpy.calibrate(FILE, output_path=GAIA_CACHE_DIR,
-                            output_file="gaia_spec_" + str(gaiaID), output_format="csv")
-        # read the flux and wavelength tables
-        gaiaflux = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv", format="csv")
-        gaiawave = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + "_sampling.csv", format="csv")
-
-    # make numpy arrays from whatever weird objects the Gaia stuff creates
-    wave = np.fromstring(gaiawave["pos"][0][1:-1], sep=",") * 10  # in Angstrom
-    # W/s/micron -> in erg/s/cm^2/A
-    flux = (1e7 * 1e-1 * 1e-4 * np.fromstring(gaiaflux["flux"][0][1:-1], sep=","))
-    return wave, flux
 
 
 def get_gaia_ids(expnum, ra, dec, lim_mag=14.0, n_ids=15, cache_dir="./gaia_cache", ignore_cache=False):
@@ -229,51 +187,6 @@ def get_gaia_xp_spectra(expnum, source_ids, cache_dir="./gaia_cache", ignore_cac
     spectra_xp.to_pickle(cache_path)
 
     return wave_xp, spectra_xp
-
-
-def get_XP_spectra(expnum, ra_tile, dec_tile, lim_mag=14.0, n_spec=15, GAIA_CACHE_DIR='./gaia_cache', ignore_cache=True, plot=False):
-    '''
-    mjd, tileid, central ra and dec, query for brightest GAIA stars in the science IFU,
-    cache their IDs, cache their XP spectra, and return a table with all the data
-    '''
-    if ignore_cache or GAIA_CACHE_DIR is None or path.exists(GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv') is False:
-        print('querying for ids ...')
-        r_ifu = np.sqrt(3.0)/2 * (30.2/2) / 60.0 # inner radius of hexagon in degrees for margin
-        select_tile = f'DISTANCE({ra_tile}, {dec_tile}, ra, dec) < {r_ifu} '
-        job = Gaia.launch_job(f"SELECT TOP {n_spec} * FROM gaiadr3.gaia_source_lite WHERE "
-                              + select_tile + f"AND phot_g_mean_mag < {lim_mag} AND has_xp_continuous = 'True' ORDER BY phot_g_mean_mag ASC ")
-        r = job.get_results()
-        if GAIA_CACHE_DIR is not None:
-            #print('writing '+GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv')
-            r.write(GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv', overwrite=True)
-    else:
-        #print('reading '+GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv')
-        r = Table.read(GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv')
-    #
-    # get XP spectra and cache the calibrated spectra
-    #
-
-    cols = r.colnames
-    new_cols = [col.lower() for col in cols]
-    r.rename_columns(cols, new_cols)
-
-    sampling=np.arange(336., 1021., 2.)
-    ids = [line['source_id'] for line in r]
-    if ignore_cache or GAIA_CACHE_DIR is None or path.exists(GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle') is False:
-        calibrated_spectra, _ = gaiaxpy.calibrate(ids, truncation=False, save_file=False)
-        if GAIA_CACHE_DIR is not None:
-            #print('writing '+GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle')
-            calibrated_spectra.to_pickle(GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle')
-    else:
-        #print('reading '+GAIA_CACHE_DIR + f'/{expnum}_XP_spec.csv')
-        calibrated_spectra = pd.read_pickle(GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle')
-
-    # calibrated_spectra
-    if(plot):
-        gaiaxpy.plot_spectra(calibrated_spectra, sampling=sampling, multi=True, show_plot=True, output_path=None, legend=False)
-    # calibrated_spectra *= 100  # W/m^2 -> erg/s/cm^
-    # astropy.Table ['SOURCE_ID, 'ra', 'dec', ...], ]pandas.DataFrame ['source_id', 'flux', 'flux_error'], np.ndarray
-    return r, calibrated_spectra, sampling
 
 
 def mean_absolute_deviation(vals):

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -9,6 +9,7 @@
 import os
 import numpy as np
 import pathlib
+import requests
 from contextlib import redirect_stdout
 from scipy import signal
 from scipy.integrate import simpson
@@ -142,6 +143,7 @@ class GaiaXPSpectra(object):
         # calibrate gaia XP coefficients into spectra
         with open(os.devnull, 'w') as f, redirect_stdout(f):
             spectra_xp = []
+            print(coeffs)
             coeffs_list = np.split(coeffs, coeffs.shape[0])
             for coeff in coeffs_list:
                 spectrum_xp, wave_xp = gaiaxpy.calibrate(coeff, sampling=self._wave_sampling,
@@ -249,6 +251,39 @@ def get_std_xp_spectrum(source_id, convert_to_cgs=True, cache_dir="./gaia_cache"
     wave_xp, spectra_xp = gaia.load_xp_spectra(source_id, convert_to_cgs=convert_to_cgs)
 
     return wave_xp, spectra_xp[0]
+
+
+def get_std_stellar_params(source_ids):
+    # Read Calibration GAIA stars table and create index on source_id for quick
+    # record retrieval
+    # https://sdss-wiki.atlassian.net/wiki/spaces/LVM/pages/14460157/Calibration+Stars
+    params_path = pathlib.Path(MASTERS_DIR) / "stellar_models" / "lvm-many_Gaia_stars_5-9_ftype_v4-all.fits"
+
+    SOURCE_IDS = ", ".join(map(str, source_ids))
+    COLUMN_NAMES = ["source_id", "teff_gspspec", "logg_gspspec", "mh_gspspec"]
+    DUMMY_TABLE = pd.DataFrame(index=source_ids, columns=COLUMN_NAMES[1:])
+
+    gaia_stars = Table.read(params_path, format='fits').to_pandas()
+    gaia_stars = gaia_stars.filter(items=COLUMN_NAMES)
+    gaia_stars.set_index('source_id', drop=True, inplace=True)
+
+    # Try to get stellar parameters from the local table first
+    try:
+        # Used indexed column source_id, See where table was read
+        stellar_params = gaia_stars.loc[source_ids]
+        log.info(f"found all {len(source_ids)} standard stars physical parameters in {params_path}")
+    except KeyError as e:
+        log.warning(e.args[0])
+        # If entry not found in local table, then call external Gaia service
+        try:
+            job = Gaia.launch_job(f"SELECT source_id, teff_gspspec, logg_gspspec, mh_gspspec FROM gaiadr3.astrophysical_parameters WHERE source_id IN ({SOURCE_IDS})")
+            stellar_params = job.get_results().to_pandas().set_index("source_id")
+            stellar_params = stellar_params.loc[source_ids]
+            log.info(f"fetched {len(source_ids)} standard stars stellar parameters")
+        except (GaiaStarNotFound, requests.exceptions.HTTPError) as e:
+            log.warning(f"{e}, returning dummy parameters")
+            stellar_params = DUMMY_TABLE.copy()
+    return stellar_params
 
 
 def mean_absolute_deviation(vals):

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -253,6 +253,28 @@ def get_std_xp_spectrum(source_id, convert_to_cgs=True, cache_dir="./gaia_cache"
     return wave_xp, spectra_xp[0]
 
 
+def get_std_xp_spectra(source_ids, cache_only=False, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+    gaia = GaiaXPSpectra(cache_dir=cache_dir)
+
+    # identify new sources if any present in cache or ignore cache and download all
+    new_ids = source_ids if ignore_cache else gaia._not_in_cache(source_ids)
+    if len(new_ids) != 0:
+        log.info(f"downloading {len(new_ids)} new XP spectra coefficients")
+        coeffs = gaia.fetch_gaia_xp_coeffs(new_ids)
+        gaia.cache_xp_spectra(coeffs)
+
+    # return if only requested caching
+    if cache_only:
+        log.info(f"cached {len(new_ids)}, returning after running with {cache_only = }")
+        return
+
+    # load XP spectra, only the old ones
+    log.info(f"loading {len(source_ids)} Gaia XP spectra with {convert_to_cgs = }")
+    wave_xp, spectra_xp = gaia.load_xp_spectra(source_ids, convert_to_cgs=convert_to_cgs)
+
+    return wave_xp, spectra_xp
+
+
 def get_std_stellar_params(source_ids):
     # Read Calibration GAIA stars table and create index on source_id for quick
     # record retrieval

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -8,6 +8,7 @@
 
 import os
 import numpy as np
+from contextlib import redirect_stdout
 from scipy import signal
 from scipy.integrate import simpson
 from scipy import interpolate
@@ -18,7 +19,7 @@ import os.path as path
 import pathlib
 from tqdm import tqdm
 
-
+import pyvo as vo
 import gaiaxpy
 from astroquery.gaia import Gaia
 
@@ -42,6 +43,7 @@ def get_mean_sens_curves(sens_dir):
     return {'b':pd.read_csv(f'{sens_dir}/mean-sens-b.csv', names=['wavelength', 'sens']),
             'r':pd.read_csv(f'{sens_dir}/mean-sens-r.csv', names=['wavelength', 'sens']),
             'z':pd.read_csv(f'{sens_dir}/mean-sens-z.csv', names=['wavelength', 'sens'])}
+
 
 def retrieve_header_stars(rss):
     """
@@ -81,14 +83,14 @@ class GaiaStarNotFound(Exception):
     pass
 
 
-def retrive_gaia_star(gaiaID, GAIA_CACHE_DIR):
+def retrive_gaia_star(gaiaID, GAIA_CACHE_DIR, ignore_cache=False):
     """
     Load or download and load from cache the XP spectrum of a gaia star, converted to erg/s/cm^2/A
     """
     # create cache dir if it does not exist
     pathlib.Path(GAIA_CACHE_DIR).mkdir(parents=True, exist_ok=True)
 
-    if path.exists(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv") is True:
+    if not ignore_cache and path.exists(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv") is True:
         # read the tables from our cache
         gaiaflux = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv", format="csv")
         gaiawave = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + "_sampling.csv", format="csv")
@@ -107,8 +109,9 @@ def retrive_gaia_star(gaiaID, GAIA_CACHE_DIR):
                 f.write(r.content.decode("utf-8"))
 
         # convert coefficients to sampled spectrum
-        _, _ = gaiaxpy.calibrate(FILE, output_path=GAIA_CACHE_DIR,\
-                                 output_file="gaia_spec_" + str(gaiaID), output_format="csv")
+        with open(os.devnull, 'w') as f, redirect_stdout(f):
+            gaiaxpy.calibrate(FILE, output_path=GAIA_CACHE_DIR,
+                            output_file="gaia_spec_" + str(gaiaID), output_format="csv")
         # read the flux and wavelength tables
         gaiaflux = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv", format="csv")
         gaiawave = Table.read(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + "_sampling.csv", format="csv")
@@ -120,12 +123,120 @@ def retrive_gaia_star(gaiaID, GAIA_CACHE_DIR):
     return wave, flux
 
 
-def get_XP_spectra(expnum, ra_tile, dec_tile, lim_mag=14.0, n_spec=15, GAIA_CACHE_DIR='./gaia_cache', plot=False):
+def get_gaia_ids(expnum, ra, dec, lim_mag=14.0, n_ids=15, cache_dir="./gaia_cache", ignore_cache=False):
+
+    IFU_INNER_RADIUS = np.sqrt(3.0)/2 * (30.2/2) / 60.0
+    TILE_GAIA_QUERY = f"""
+        SELECT TOP {n_ids} * FROM gaiadr3.gaia_source_lite WHERE
+        DISTANCE({ra}, {dec}, ra, dec) < {IFU_INNER_RADIUS}
+        AND phot_g_mean_mag < {lim_mag} AND has_xp_continuous = 'True' ORDER BY phot_g_mean_mag ASC"""
+
+    cache_path = os.path.join(cache_dir, f"{expnum}_ids.ecsv")
+    if not ignore_cache and path.exists(cache_path):
+        log.info(f"loading Gaia IDs for {expnum = } from {cache_path}")
+        gaia_table = Table.read(cache_path)
+    else:
+        log.info(f'querying {n_ids} Gaia IDs for {expnum = } with G < {lim_mag} mag')
+        job = Gaia.launch_job(TILE_GAIA_QUERY)
+        gaia_table = job.get_results()
+
+        log.info(f"caching Gaia IDs for {expnum = } to {cache_path}")
+        gaia_table.write(cache_path, overwrite=True)
+
+    # clean up columns
+    cols = gaia_table.colnames
+    new_cols = [col.lower() for col in cols]
+    gaia_table.rename_columns(cols, new_cols)
+
+    return gaia_table
+
+
+def get_gaia_xp_spectrum(source_id, cache_dir="./gaia_cache", ignore_cache=False):
+
+    output_name = f"gaia_spec_{source_id}"
+    spectrum_path = os.path.join(cache_dir, f"{output_name}.csv")
+    wavelength_path = os.path.join(cache_dir, f"{output_name}_sampling.csv")
+    if not ignore_cache and os.path.exists(spectrum_path) and os.path.exists(wavelength_path):
+        log.info(f"loading Gaia XP spetrum for ID = {source_id} files labelled {output_name}")
+        wave_xp = Table.read(wavelength_path, format="csv")
+        spectrum_xp = Table.read(spectrum_path, format="csv")
+    else:
+        # define origin DB
+        tap_service = vo.dal.TAPService("https://gaia.aip.de/tap")
+
+        # define query for XP coefficients
+        GAIA_XP_QUERY = f"""
+            SELECT * FROM gaiadr3.xp_continuous_mean_spectrum
+            WHERE source_id = {source_id}
+        """
+        # summit query
+        log.info(f"querying the AIP Gaia mirror for ID = {source_id} XP spectra")
+        job = tap_service.run_sync(GAIA_XP_QUERY)
+
+        # parse pandas dataframe and strip masked arrays
+        coeffs = job.to_table().to_pandas()
+        for col in coeffs.columns:
+            if coeffs[col].dtype == 'object':
+                coeffs[col] = coeffs[col].apply(lambda x: np.array(x.data) if isinstance(x, np.ma.MaskedArray) else x)
+
+        # calibrate gaia XP coefficients into spectra
+        wave_xp = np.arange(336, 1021, 2)
+        log.info(f"caching Gaia XP spectrum for ID = {source_id} with label {output_name}")
+        with open(os.devnull, 'w') as f, redirect_stdout(f):
+            spectrum_xp, _ = gaiaxpy.calibrate(coeffs, sampling=wave_xp, truncation=False, save_file=True,
+                                            output_path=cache_dir, output_file=output_name, output_format="csv")
+
+    wave_xp *= 10
+    # W/s/micron -> in erg/s/cm^2/A
+    spectrum_xp = spectrum_xp.loc[0, "flux"] * 1e7 * 1e-1 * 1e-4
+    return wave_xp, spectrum_xp
+
+
+def get_gaia_xp_spectra(expnum, source_ids, cache_dir="./gaia_cache", ignore_cache=False, plot=False):
+
+    wave_xp = np.arange(336, 1021, 2)
+    cache_path = os.path.join(cache_dir, f"{expnum}_XP_spec.pickle")
+    if not ignore_cache and os.path.exists(cache_path):
+        log.info(f"loading Gaia XP spectra for {expnum = } from {cache_path}")
+        spectra_xp = pd.read_pickle(cache_path)
+        return wave_xp, spectra_xp
+
+    # define origin DB
+    tap_service = vo.dal.TAPService("https://gaia.aip.de/tap")
+
+    # define query for XP coefficients
+    id_string = ", ".join(map(str, source_ids))
+    GAIA_XP_QUERY = f"""
+        SELECT * FROM gaiadr3.xp_continuous_mean_spectrum
+        WHERE source_id IN ({id_string})
+    """
+
+    # summit query
+    log.info(f"querying the AIP Gaia mirror for {len(source_ids)} XP spectra")
+    job = tap_service.run_sync(GAIA_XP_QUERY)
+
+    # parse pandas dataframe and strip masked arrays
+    coeffs = job.to_table().to_pandas()
+    for col in coeffs.columns:
+        if coeffs[col].dtype == 'object':
+            coeffs[col] = coeffs[col].apply(lambda x: np.array(x.data) if isinstance(x, np.ma.MaskedArray) else x)
+
+    # calibrate gaia XP coefficients into spectra
+    with open(os.devnull, 'w') as f, redirect_stdout(f):
+        spectra_xp, _ = gaiaxpy.calibrate(coeffs, sampling=wave_xp, truncation=False, save_file=False)
+
+    log.info(f"caching Gaia XP spectra for {expnum = } to {cache_path}")
+    spectra_xp.to_pickle(cache_path)
+
+    return wave_xp, spectra_xp
+
+
+def get_XP_spectra(expnum, ra_tile, dec_tile, lim_mag=14.0, n_spec=15, GAIA_CACHE_DIR='./gaia_cache', ignore_cache=True, plot=False):
     '''
     mjd, tileid, central ra and dec, query for brightest GAIA stars in the science IFU,
     cache their IDs, cache their XP spectra, and return a table with all the data
     '''
-    if GAIA_CACHE_DIR is None or path.exists(GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv') is False:
+    if ignore_cache or GAIA_CACHE_DIR is None or path.exists(GAIA_CACHE_DIR + f'/{expnum}_ids.ecsv') is False:
         print('querying for ids ...')
         r_ifu = np.sqrt(3.0)/2 * (30.2/2) / 60.0 # inner radius of hexagon in degrees for margin
         select_tile = f'DISTANCE({ra_tile}, {dec_tile}, ra, dec) < {r_ifu} '
@@ -148,7 +259,7 @@ def get_XP_spectra(expnum, ra_tile, dec_tile, lim_mag=14.0, n_spec=15, GAIA_CACH
 
     sampling=np.arange(336., 1021., 2.)
     ids = [line['source_id'] for line in r]
-    if GAIA_CACHE_DIR is None or path.exists(GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle') is False:
+    if ignore_cache or GAIA_CACHE_DIR is None or path.exists(GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle') is False:
         calibrated_spectra, _ = gaiaxpy.calibrate(ids, truncation=False, save_file=False)
         if GAIA_CACHE_DIR is not None:
             #print('writing '+GAIA_CACHE_DIR + f'/{expnum}_XP_spec.pickle')

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -8,13 +8,13 @@
 
 import os
 import numpy as np
+import pathlib
 from contextlib import redirect_stdout
 from scipy import signal
 from scipy.integrate import simpson
 from scipy import interpolate
 import pandas as pd
 import bottleneck as bn
-import os.path as path
 from tqdm import tqdm
 
 import pyvo as vo
@@ -36,6 +36,10 @@ from lvmdrp.core.rss import RSS
 
 from scipy.sparse import csr_matrix
 
+import warnings
+
+# pandas mute warnings about .swapaxes method
+warnings.filterwarnings("ignore", message='.*DataFrame.swapaxes.*')
 
 def get_mean_sens_curves(sens_dir):
     return {'b':pd.read_csv(f'{sens_dir}/mean-sens-b.csv', names=['wavelength', 'sens']),
@@ -81,59 +85,49 @@ class GaiaStarNotFound(Exception):
     pass
 
 
-def get_gaia_ids(expnum, ra, dec, lim_mag=14.0, n_ids=15, cache_dir="./gaia_cache", ignore_cache=False):
+class GaiaXPSpectra(object):
+    def __init__(self, cache_dir="./gaia_cache"):
+        self.cache_dir = pathlib.Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    IFU_INNER_RADIUS = np.sqrt(3.0)/2 * (30.2/2) / 60.0
-    TILE_GAIA_QUERY = f"""
-        SELECT TOP {n_ids} * FROM gaiadr3.gaia_source_lite WHERE
-        DISTANCE({ra}, {dec}, ra, dec) < {IFU_INNER_RADIUS}
-        AND phot_g_mean_mag < {lim_mag} AND has_xp_continuous = 'True' ORDER BY phot_g_mean_mag ASC"""
+        self._wave_sampling = np.arange(336, 1021, 2)
 
-    cache_path = os.path.join(cache_dir, f"{expnum}_ids.ecsv")
-    if not ignore_cache and path.exists(cache_path):
-        log.info(f"loading Gaia IDs for {expnum = } from {cache_path}")
-        gaia_table = Table.read(cache_path)
-    else:
-        log.info(f'querying {n_ids} Gaia IDs for {expnum = } with G < {lim_mag} mag')
-        job = Gaia.launch_job(TILE_GAIA_QUERY)
-        gaia_table = job.get_results()
+    def _get_xp_spectrum_paths(self, source_id):
+        output_name = f"gaia_spec_{source_id}"
+        wave_path = self.cache_dir / f"{output_name}_sampling.csv"
+        spec_path = self.cache_dir / f"{output_name}.csv"
+        return wave_path, spec_path
 
-        log.info(f"caching Gaia IDs for {expnum = } to {cache_path}")
-        gaia_table.write(cache_path, overwrite=True)
+    def _xp_spectrum_exists(self, source_id):
+        wave_path, spec_path = self._get_xp_spectrum_paths(source_id)
+        return wave_path.exists() and spec_path.exists()
 
-    # clean up columns
-    cols = gaia_table.colnames
-    new_cols = [col.lower() for col in cols]
-    gaia_table.rename_columns(cols, new_cols)
+    def _not_in_cache(self, source_ids):
+        new_ids = list(filter(lambda source_id: not self._xp_spectrum_exists(source_id), source_ids))
+        return new_ids
 
-    return gaia_table
+    def _convert_to_csg(self, wave_xp, spectra_xp):
+        # micron -> A
+        wave_xp *= 10
+        # W/s/micron -> erg/s/cm^2/A
+        spectra_xp *= 1e7 * 1e-1 * 1e-4
+        return wave_xp, spectra_xp
 
+    def fetch_gaia_xp_coeffs(self, source_ids):
 
-def get_gaia_xp_spectrum(source_id, cache_dir="./gaia_cache", ignore_cache=False):
-
-    output_name = f"gaia_spec_{source_id}"
-    spectrum_path = os.path.join(cache_dir, f"{output_name}.csv")
-    wavelength_path = os.path.join(cache_dir, f"{output_name}_sampling.csv")
-    if not ignore_cache and os.path.exists(spectrum_path) and os.path.exists(wavelength_path):
-        log.info(f"loading Gaia XP spetrum for ID = {source_id} files labelled {output_name}")
-        wave_xp = Table.read(wavelength_path, format="csv")
-        spectrum_xp = Table.read(spectrum_path, format="csv")
-
-        # make numpy arrays from whatever weird objects the Gaia stuff creates
-        wave_xp = np.fromstring(wave_xp["pos"][0][1:-1], sep=",")
-        # W/s/micron -> in erg/s/cm^2/A
-        spectrum_xp = np.fromstring(spectrum_xp["flux"][0][1:-1], sep=",")
-    else:
         # define origin DB
         tap_service = vo.dal.TAPService("https://gaia.aip.de/tap")
 
         # define query for XP coefficients
+        if isinstance(source_ids, (int, str)):
+            source_ids = [source_ids]
+        id_string = ", ".join(map(str, source_ids))
         GAIA_XP_QUERY = f"""
             SELECT * FROM gaiadr3.xp_continuous_mean_spectrum
-            WHERE source_id = {source_id}
+            WHERE source_id IN ({id_string})
         """
+
         # summit query
-        log.info(f"querying the AIP Gaia mirror for ID = {source_id} XP spectra")
         job = tap_service.run_sync(GAIA_XP_QUERY)
 
         # parse pandas dataframe and strip masked arrays
@@ -142,57 +136,119 @@ def get_gaia_xp_spectrum(source_id, cache_dir="./gaia_cache", ignore_cache=False
             if coeffs[col].dtype == 'object':
                 coeffs[col] = coeffs[col].apply(lambda x: np.array(x.data) if isinstance(x, np.ma.MaskedArray) else x)
 
+        return coeffs
+
+    def cache_xp_spectra(self, coeffs, convert_to_cgs=True):
         # calibrate gaia XP coefficients into spectra
-        wave_xp = np.arange(336, 1021, 2)
-        log.info(f"caching Gaia XP spectrum for ID = {source_id} with label {output_name}")
         with open(os.devnull, 'w') as f, redirect_stdout(f):
-            spectrum_xp, _ = gaiaxpy.calibrate(coeffs, sampling=wave_xp, truncation=False, save_file=True,
-                                               output_path=cache_dir, output_file=output_name, output_format="csv")
-        spectrum_xp = spectrum_xp.loc[0, "flux"]
+            spectra_xp = []
+            coeffs_list = np.split(coeffs, coeffs.shape[0])
+            for coeff in coeffs_list:
+                spectrum_xp, wave_xp = gaiaxpy.calibrate(coeff, sampling=self._wave_sampling,
+                                                         truncation=False, save_file=True, output_path=self.cache_dir,
+                                                         output_file=f"gaia_spec_{coeff.iloc[0].source_id}", output_format="csv")
+                spectra_xp.append(spectrum_xp.loc[0, "flux"])
+        spectra_xp = np.row_stack(spectra_xp)
 
-    wave_xp *= 10
-    # W/s/micron -> in erg/s/cm^2/A
-    spectrum_xp *= 1e7 * 1e-1 * 1e-4
-    return wave_xp, spectrum_xp
+        if convert_to_cgs:
+            return self._convert_to_csg(wave_xp, spectra_xp)
 
-
-def get_gaia_xp_spectra(expnum, source_ids, cache_dir="./gaia_cache", ignore_cache=False, plot=False):
-
-    wave_xp = np.arange(336, 1021, 2)
-    cache_path = os.path.join(cache_dir, f"{expnum}_XP_spec.pickle")
-    if not ignore_cache and os.path.exists(cache_path):
-        log.info(f"loading Gaia XP spectra for {expnum = } from {cache_path}")
-        spectra_xp = pd.read_pickle(cache_path)
         return wave_xp, spectra_xp
 
-    # define origin DB
-    tap_service = vo.dal.TAPService("https://gaia.aip.de/tap")
+    def load_xp_spectra(self, source_ids, convert_to_cgs=True):
 
-    # define query for XP coefficients
-    id_string = ", ".join(map(str, source_ids))
-    GAIA_XP_QUERY = f"""
-        SELECT * FROM gaiadr3.xp_continuous_mean_spectrum
-        WHERE source_id IN ({id_string})
-    """
+        if isinstance(source_ids, (list, tuple, set, np.ndarray)):
+            spectra_xp = []
+            for source_id in source_ids:
+                wave_xp, spectrum = self.load_xp_spectra(source_ids=source_id, convert_to_cgs=False)
+                spectra_xp.append(spectrum)
+            spectra_xp = np.row_stack(spectra_xp)
 
-    # summit query
-    log.info(f"querying the AIP Gaia mirror for {len(source_ids)} XP spectra")
-    job = tap_service.run_sync(GAIA_XP_QUERY)
+            if convert_to_cgs:
+                return self._convert_to_csg(wave_xp, spectra_xp)
 
-    # parse pandas dataframe and strip masked arrays
-    coeffs = job.to_table().to_pandas()
-    for col in coeffs.columns:
-        if coeffs[col].dtype == 'object':
-            coeffs[col] = coeffs[col].apply(lambda x: np.array(x.data) if isinstance(x, np.ma.MaskedArray) else x)
+            return wave_xp, spectra_xp
 
-    # calibrate gaia XP coefficients into spectra
-    with open(os.devnull, 'w') as f, redirect_stdout(f):
-        spectra_xp, _ = gaiaxpy.calibrate(coeffs, sampling=wave_xp, truncation=False, save_file=False)
+        if not self._xp_spectrum_exists(source_ids):
+            raise ValueError(f"{source_ids = } not present in cache directory {self.cache_dir}")
 
-    log.info(f"caching Gaia XP spectra for {expnum = } to {cache_path}")
-    spectra_xp.to_pickle(cache_path)
+        wavelength_path, spectrum_path = self._get_xp_spectrum_paths(source_ids)
+        wave_xp = Table.read(wavelength_path, format="csv")
+        spectrum_xp = Table.read(spectrum_path, format="csv")
 
+        # make numpy arrays from whatever weird objects the Gaia stuff creates
+        wave_xp = np.fromstring(wave_xp["pos"][0][1:-1], sep=",")
+        spectrum_xp = np.atleast_2d(np.fromstring(spectrum_xp["flux"][0][1:-1], sep=","))
+
+        if convert_to_cgs:
+            return self._convert_to_csg(wave_xp, spectrum_xp)
+        return wave_xp, spectrum_xp
+
+    def fetch_ids_for_tile(self, expnum, ra, dec, lim_mag=14.0, n_ids=15, ignore_cache=False):
+
+        IFU_INNER_RADIUS = np.sqrt(3.0)/2 * (30.2/2) / 60.0
+        TILE_GAIA_QUERY = f"""
+            SELECT TOP {n_ids} * FROM gaiadr3.gaia_source_lite WHERE
+            DISTANCE({ra}, {dec}, ra, dec) < {IFU_INNER_RADIUS}
+            AND phot_g_mean_mag < {lim_mag} AND has_xp_continuous = 'True' ORDER BY phot_g_mean_mag ASC"""
+
+        cache_path = self.cache_dir / f"{expnum}_ids.ecsv"
+        if not ignore_cache and cache_path.exists():
+            gaia_table = Table.read(cache_path, format="ascii.ecsv")
+        else:
+            job = Gaia.launch_job(TILE_GAIA_QUERY)
+            gaia_table = job.get_results()
+            gaia_table.write(cache_path, format="ascii.ecsv", serialize_method="data_mask", overwrite=True)
+
+        # clean up columns
+        cols = gaia_table.colnames
+        new_cols = [col.lower() for col in cols]
+        gaia_table.rename_columns(cols, new_cols)
+
+        return gaia_table
+
+
+def get_tile_xp_spectra(expnum, ra, dec, lim_mag=14.0, n_spectra=15, return_table=False, cache_only=False, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+    gaia = GaiaXPSpectra(cache_dir=cache_dir)
+
+    log.info(f"fetching {n_spectra} Gaia sources for {expnum = } with G < {lim_mag} mag")
+    gaia_table = gaia.fetch_ids_for_tile(expnum, ra, dec, lim_mag=lim_mag, n_ids=n_spectra, ignore_cache=ignore_cache)
+
+    source_ids = gaia_table["source_id"].filled().data
+    # identify new sources if any present in cache or ignore cache and download all
+    new_ids = source_ids if ignore_cache else gaia._not_in_cache(source_ids)
+    if len(new_ids) != 0:
+        log.info(f"downloading {len(new_ids)} new XP spectra coefficients")
+        coeffs = gaia.fetch_gaia_xp_coeffs(new_ids)
+        gaia.cache_xp_spectra(coeffs)
+
+    # return if only requested caching
+    if cache_only:
+        log.info(f"cached {len(new_ids)} for {expnum = }, returning after running with {cache_only = }")
+        return
+
+    # load XP spectra, only the old ones
+    log.info(f"loading {len(source_ids)} Gaia XP spectra with {convert_to_cgs = }")
+    wave_xp, spectra_xp = gaia.load_xp_spectra(source_ids, convert_to_cgs=convert_to_cgs)
+
+    if return_table:
+        return wave_xp, spectra_xp, gaia_table
     return wave_xp, spectra_xp
+
+
+def get_std_xp_spectrum(source_id, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+    gaia = GaiaXPSpectra(cache_dir=cache_dir)
+
+    if ignore_cache or not gaia._xp_spectrum_exists(source_id):
+        log.info(f"downloading new XP spectrum coefficients for {source_id = }")
+        coeffs = gaia.fetch_gaia_xp_coeffs(source_id)
+        wave_xp, spectra_xp = gaia.cache_xp_spectra(coeffs, convert_to_cgs=convert_to_cgs)
+        return wave_xp, spectra_xp[0]
+
+    log.info(f"loading Gaia XP spectrum for {source_id = } and {convert_to_cgs = }")
+    wave_xp, spectra_xp = gaia.load_xp_spectra(source_id, convert_to_cgs=convert_to_cgs)
+
+    return wave_xp, spectra_xp[0]
 
 
 def mean_absolute_deviation(vals):

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -118,6 +118,11 @@ def get_gaia_xp_spectrum(source_id, cache_dir="./gaia_cache", ignore_cache=False
         log.info(f"loading Gaia XP spetrum for ID = {source_id} files labelled {output_name}")
         wave_xp = Table.read(wavelength_path, format="csv")
         spectrum_xp = Table.read(spectrum_path, format="csv")
+
+        # make numpy arrays from whatever weird objects the Gaia stuff creates
+        wave_xp = np.fromstring(wave_xp["pos"][0][1:-1], sep=",")
+        # W/s/micron -> in erg/s/cm^2/A
+        spectrum_xp = np.fromstring(spectrum_xp["flux"][0][1:-1], sep=",")
     else:
         # define origin DB
         tap_service = vo.dal.TAPService("https://gaia.aip.de/tap")
@@ -142,11 +147,12 @@ def get_gaia_xp_spectrum(source_id, cache_dir="./gaia_cache", ignore_cache=False
         log.info(f"caching Gaia XP spectrum for ID = {source_id} with label {output_name}")
         with open(os.devnull, 'w') as f, redirect_stdout(f):
             spectrum_xp, _ = gaiaxpy.calibrate(coeffs, sampling=wave_xp, truncation=False, save_file=True,
-                                            output_path=cache_dir, output_file=output_name, output_format="csv")
+                                               output_path=cache_dir, output_file=output_name, output_format="csv")
+        spectrum_xp = spectrum_xp.loc[0, "flux"]
 
     wave_xp *= 10
     # W/s/micron -> in erg/s/cm^2/A
-    spectrum_xp = spectrum_xp.loc[0, "flux"] * 1e7 * 1e-1 * 1e-4
+    spectrum_xp *= 1e7 * 1e-1 * 1e-4
     return wave_xp, spectrum_xp
 
 

--- a/python/lvmdrp/core/fluxcal.py
+++ b/python/lvmdrp/core/fluxcal.py
@@ -9,7 +9,6 @@
 import os
 import numpy as np
 import pathlib
-import requests
 from contextlib import redirect_stdout
 from scipy import signal
 from scipy.integrate import simpson
@@ -78,43 +77,110 @@ def retrieve_header_stars(rss):
     return stddata
 
 
-class GaiaStarNotFound(Exception):
-    """
-    Signal that the star has no BP-RP spectrum
-    """
-
-    pass
-
-
 class GaiaXPSpectra(object):
+    """Manage Gaia XP spectrophotometry retrieval, caching, and loading.
+
+    This class fetches Gaia DR3 XP coefficient data, converts coefficients into
+    sampled spectra, caches results locally, and loads cached spectra on demand.
+    """
+
     def __init__(self, cache_dir="./gaia_cache"):
+        """Initialize the GaiaXPSpectra cache manager.
+
+        Parameters
+        ----------
+        cache_dir : str, optional
+            Directory where Gaia XP spectrum cache files are stored.
+        """
         self.cache_dir = pathlib.Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
         self._wave_sampling = np.arange(336, 1021, 2)
 
     def _get_xp_spectrum_paths(self, source_id):
+        """Return the expected cache file paths for a Gaia source.
+
+        Parameters
+        ----------
+        source_id : int or str
+            Gaia source identifier.
+
+        Returns
+        -------
+        tuple[pathlib.Path, pathlib.Path]
+            Paths for the wavelength sampling and spectrum CSV files.
+        """
         output_name = f"gaia_spec_{source_id}"
         wave_path = self.cache_dir / f"{output_name}_sampling.csv"
         spec_path = self.cache_dir / f"{output_name}.csv"
         return wave_path, spec_path
 
     def _xp_spectrum_exists(self, source_id):
+        """Return whether a cached XP spectrum exists for the source.
+
+        Parameters
+        ----------
+        source_id : int or str
+            Gaia source identifier.
+
+        Returns
+        -------
+        bool
+            True if both sampling and spectrum cache files exist.
+        """
         wave_path, spec_path = self._get_xp_spectrum_paths(source_id)
         return wave_path.exists() and spec_path.exists()
 
     def _not_in_cache(self, source_ids):
+        """Filter source IDs that are not already cached.
+
+        Parameters
+        ----------
+        source_ids : iterable
+            Gaia source identifiers to check.
+
+        Returns
+        -------
+        list
+            IDs that are missing from the local cache.
+        """
         new_ids = list(filter(lambda source_id: not self._xp_spectrum_exists(source_id), source_ids))
         return new_ids
 
     def _convert_to_csg(self, wave_xp, spectra_xp):
+        """Convert Gaia XP spectrum units to wavelength in Angstrom and flux in CGS.
+
+        Parameters
+        ----------
+        wave_xp : ndarray
+            Wavelength sampling array in microns.
+        spectra_xp : ndarray
+            Flux array in W/s/micron.
+
+        Returns
+        -------
+        tuple[ndarray, ndarray]
+            Converted wavelength and flux arrays.
+        """
         # micron -> A
         wave_xp *= 10
         # W/s/micron -> erg/s/cm^2/A
         spectra_xp *= 1e7 * 1e-1 * 1e-4
         return wave_xp, spectra_xp
 
-    def fetch_gaia_xp_coeffs(self, source_ids):
+    def fetch_xp_coeffs(self, source_ids):
+        """Fetch Gaia XP coefficients from the Gaia TAP service.
+
+        Parameters
+        ----------
+        source_ids : int, str, or sequence
+            Gaia DR3 source identifier or identifiers.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Coefficients for the requested XP spectra.
+        """
 
         # define origin DB
         tap_service = vo.dal.TAPService("https://gaia.aip.de/tap")
@@ -140,6 +206,20 @@ class GaiaXPSpectra(object):
         return coeffs
 
     def cache_xp_spectra(self, coeffs, convert_to_cgs=True):
+        """Calibrate Gaia XP coefficients to spectra and save them to cache.
+
+        Parameters
+        ----------
+        coeffs : pandas.DataFrame
+            Result of :meth:`fetch_xp_coeffs` containing XP coefficients.
+        convert_to_cgs : bool, optional
+            If True, convert outputs to CGS units.
+
+        Returns
+        -------
+        tuple[ndarray, ndarray]
+            Wavelength sampling and stacked spectrum array for the last source.
+        """
         # calibrate gaia XP coefficients into spectra
         with open(os.devnull, 'w') as f, redirect_stdout(f):
             spectra_xp = []
@@ -158,6 +238,20 @@ class GaiaXPSpectra(object):
         return wave_xp, spectra_xp
 
     def load_xp_spectra(self, source_ids, convert_to_cgs=True):
+        """Load cached XP spectra for one or more Gaia source IDs.
+
+        Parameters
+        ----------
+        source_ids : int or sequence
+            Gaia source identifier or identifiers.
+        convert_to_cgs : bool, optional
+            If True, convert loaded spectra to CGS units.
+
+        Returns
+        -------
+        tuple[ndarray, ndarray]
+            Wavelength sampling and one- or two-dimensional flux array.
+        """
 
         if isinstance(source_ids, (list, tuple, set, np.ndarray)):
             spectra_xp = []
@@ -186,7 +280,29 @@ class GaiaXPSpectra(object):
             return self._convert_to_csg(wave_xp, spectrum_xp)
         return wave_xp, spectrum_xp
 
-    def fetch_ids_for_tile(self, expnum, ra, dec, lim_mag=14.0, n_ids=15, ignore_cache=False):
+    def fetch_sources(self, label, ra, dec, lim_mag=14.0, n_ids=15, ignore_cache=False):
+        """Fetch nearby Gaia sources with XP spectra and cache the query results.
+
+        Parameters
+        ----------
+        label : str
+            Cache label used to write the source ID file.
+        ra : float
+            Tile center right ascension in degrees.
+        dec : float
+            Tile center declination in degrees.
+        lim_mag : float, optional
+            Maximum Gaia G magnitude for selected sources.
+        n_ids : int, optional
+            Number of sources to retrieve.
+        ignore_cache : bool, optional
+            If True, ignore cached source lists and refetch from Gaia.
+
+        Returns
+        -------
+        astropy.table.Table
+            Gaia source table for the selected nearby objects.
+        """
 
         IFU_INNER_RADIUS = np.sqrt(3.0)/2 * (30.2/2) / 60.0
         TILE_GAIA_QUERY = f"""
@@ -194,7 +310,7 @@ class GaiaXPSpectra(object):
             DISTANCE({ra}, {dec}, ra, dec) < {IFU_INNER_RADIUS}
             AND phot_g_mean_mag < {lim_mag} AND has_xp_continuous = 'True' ORDER BY phot_g_mean_mag ASC"""
 
-        cache_path = self.cache_dir / f"{expnum}_ids.ecsv"
+        cache_path = self.cache_dir / f"{label}_ids.ecsv"
         if not ignore_cache and cache_path.exists():
             gaia_table = Table.read(cache_path, format="ascii.ecsv")
         else:
@@ -209,21 +325,72 @@ class GaiaXPSpectra(object):
 
         return gaia_table
 
+    def fetch_xp_spectra(self, source_ids, ignore_cache=False):
+        """Fetch and cache XP spectra for requested Gaia source IDs.
 
-def get_tile_xp_spectra(expnum, ra, dec, lim_mag=14.0, n_spectra=15, return_table=False, cache_only=False, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+        Parameters
+        ----------
+        source_ids : sequence
+            Gaia source identifiers whose spectra should be retrieved.
+        ignore_cache : bool, optional
+            If True, force download even if cached spectra exist.
+
+        Returns
+        -------
+        list
+            Source IDs that were newly downloaded and cached.
+        """
+
+        # identify new sources if any present in cache or ignore cache and download all
+        new_ids = source_ids if ignore_cache else self._not_in_cache(source_ids)
+        if len(new_ids) != 0:
+            log.info(f"downloading {len(new_ids)} new XP spectra coefficients")
+            coeffs = self.fetch_xp_coeffs(new_ids)
+            self.cache_xp_spectra(coeffs)
+
+        return new_ids
+
+
+def get_xp_spectra_from_tile(expnum, ra, dec, lim_mag=14.0, n_spectra=15, return_table=False, cache_only=False, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+    """Retrieve Gaia XP spectra for a tile centered at RA/Dec.
+
+    Parameters
+    ----------
+    expnum : str
+        Exposure number or tile label used for cache naming.
+    ra : float
+        Right ascension of the tile center in degrees.
+    dec : float
+        Declination of the tile center in degrees.
+    lim_mag : float, optional
+        Maximum Gaia G magnitude for returned sources.
+    n_spectra : int, optional
+        Number of Gaia sources to retrieve.
+    return_table : bool, optional
+        If True, also return the Gaia source table.
+    cache_only : bool, optional
+        If True, only download and cache spectra without loading them.
+    convert_to_cgs : bool, optional
+        If True, convert loaded spectra to CGS units.
+    cache_dir : str, optional
+        Directory used for Gaia cache files.
+    ignore_cache : bool, optional
+        If True, ignore existing cache and refetch all data.
+
+    Returns
+    -------
+    tuple
+        If return_table is False, returns (wave_xp, spectra_xp).
+        If return_table is True, returns (wave_xp, spectra_xp, gaia_table).
+    """
     gaia = GaiaXPSpectra(cache_dir=cache_dir)
 
     log.info(f"fetching {n_spectra} Gaia sources for {expnum = } with G < {lim_mag} mag")
-    gaia_table = gaia.fetch_ids_for_tile(expnum, ra, dec, lim_mag=lim_mag, n_ids=n_spectra, ignore_cache=ignore_cache)
+    gaia_table = gaia.fetch_sources(expnum, ra, dec, lim_mag=lim_mag, n_ids=n_spectra, ignore_cache=ignore_cache)
 
+    # download new XP spectra
     source_ids = gaia_table["source_id"].filled().data
-    # identify new sources if any present in cache or ignore cache and download all
-    new_ids = source_ids if ignore_cache else gaia._not_in_cache(source_ids)
-    if len(new_ids) != 0:
-        log.info(f"downloading {len(new_ids)} new XP spectra coefficients")
-        coeffs = gaia.fetch_gaia_xp_coeffs(new_ids)
-        gaia.cache_xp_spectra(coeffs)
-
+    new_ids = gaia.fetch_xp_spectra(source_ids, ignore_cache=ignore_cache)
     # return if only requested caching
     if cache_only:
         log.info(f"cached {len(new_ids)} for {expnum = }, returning after running with {cache_only = }")
@@ -238,30 +405,35 @@ def get_tile_xp_spectra(expnum, ra, dec, lim_mag=14.0, n_spectra=15, return_tabl
     return wave_xp, spectra_xp
 
 
-def get_std_xp_spectrum(source_id, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+def get_xp_spectra_from_ids(source_ids, cache_only=False, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
+    """Fetch Gaia XP spectra for the specified source IDs.
+
+    Parameters
+    ----------
+    source_ids : int or sequence
+        Gaia source identifier(s) to retrieve.
+    cache_only : bool, optional
+        If True, only cache the spectra and do not load them.
+    convert_to_cgs : bool, optional
+        If True, convert loaded spectra to CGS units.
+    cache_dir : str, optional
+        Directory used for Gaia cache files.
+    ignore_cache : bool, optional
+        If True, re-download spectra even if cached.
+
+    Returns
+    -------
+    tuple[ndarray, ndarray]
+        Wavelength sampling and spectra array unless cache_only is True.
+    """
+
+    if isinstance(source_ids, int):
+        source_ids = [source_ids]
+
     gaia = GaiaXPSpectra(cache_dir=cache_dir)
 
-    if ignore_cache or not gaia._xp_spectrum_exists(source_id):
-        log.info(f"downloading new XP spectrum coefficients for {source_id = }")
-        coeffs = gaia.fetch_gaia_xp_coeffs(source_id)
-        wave_xp, spectra_xp = gaia.cache_xp_spectra(coeffs, convert_to_cgs=convert_to_cgs)
-        return wave_xp, spectra_xp[0]
-
-    log.info(f"loading Gaia XP spectrum for {source_id = } and {convert_to_cgs = }")
-    wave_xp, spectra_xp = gaia.load_xp_spectra(source_id, convert_to_cgs=convert_to_cgs)
-
-    return wave_xp, spectra_xp[0]
-
-
-def get_std_xp_spectra(source_ids, cache_only=False, convert_to_cgs=True, cache_dir="./gaia_cache", ignore_cache=False):
-    gaia = GaiaXPSpectra(cache_dir=cache_dir)
-
-    # identify new sources if any present in cache or ignore cache and download all
-    new_ids = source_ids if ignore_cache else gaia._not_in_cache(source_ids)
-    if len(new_ids) != 0:
-        log.info(f"downloading {len(new_ids)} new XP spectra coefficients")
-        coeffs = gaia.fetch_gaia_xp_coeffs(new_ids)
-        gaia.cache_xp_spectra(coeffs)
+    # download new XP spectra
+    new_ids = gaia.fetch_xp_spectra(source_ids, ignore_cache=ignore_cache)
 
     # return if only requested caching
     if cache_only:
@@ -275,7 +447,25 @@ def get_std_xp_spectra(source_ids, cache_only=False, convert_to_cgs=True, cache_
     return wave_xp, spectra_xp
 
 
-def get_std_stellar_params(source_ids):
+def get_stellar_params(source_ids):
+    """Retrieve stellar physical parameters for Gaia source IDs.
+
+    This function first attempts to read stellar parameters from a local
+    calibration table in the masters directory. If any requested source IDs are
+    missing from the local table, it queries Gaia DR3 astrophysical parameters
+    and falls back to a dummy parameter table if the external query fails.
+
+    Parameters
+    ----------
+    source_ids : sequence
+        Gaia source identifiers for which to retrieve stellar parameters.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Stellar parameters indexed by source_id, including teff_gspspec,
+        logg_gspspec, and mh_gspspec.
+    """
     # Read Calibration GAIA stars table and create index on source_id for quick
     # record retrieval
     # https://sdss-wiki.atlassian.net/wiki/spaces/LVM/pages/14460157/Calibration+Stars
@@ -284,6 +474,7 @@ def get_std_stellar_params(source_ids):
     SOURCE_IDS = ", ".join(map(str, source_ids))
     COLUMN_NAMES = ["source_id", "teff_gspspec", "logg_gspspec", "mh_gspspec"]
     DUMMY_TABLE = pd.DataFrame(index=source_ids, columns=COLUMN_NAMES[1:])
+    DUMMY_TABLE.index.name = "source_id"
 
     gaia_stars = Table.read(params_path, format='fits').to_pandas()
     gaia_stars = gaia_stars.filter(items=COLUMN_NAMES)
@@ -302,7 +493,7 @@ def get_std_stellar_params(source_ids):
             stellar_params = job.get_results().to_pandas().set_index("source_id")
             stellar_params = stellar_params.loc[source_ids]
             log.info(f"fetched {len(source_ids)} standard stars stellar parameters")
-        except (GaiaStarNotFound, requests.exceptions.HTTPError) as e:
+        except Exception as e:
             log.warning(f"{e}, returning dummy parameters")
             stellar_params = DUMMY_TABLE.copy()
     return stellar_params

--- a/python/lvmdrp/external/ancillary_func.py
+++ b/python/lvmdrp/external/ancillary_func.py
@@ -1,10 +1,4 @@
-import os.path as path
-import pathlib
-
 import numpy
-import requests
-from astropy.table import Table
-from gaiaxpy import calibrate
 from scipy import interpolate
 try:
     from scipy.integrate import simps
@@ -127,68 +121,6 @@ def interpolate_mask(x, y, mask, kind="linear", fill_value=0):
     yy[missing_idx] = f(missing_x)
 
     return yy
-
-
-class GaiaStarNotFound(Exception):
-    """
-    Signal that the star has no BP-RP spectrum
-    """
-
-    pass
-
-
-def retrive_gaia_star(gaiaID, GAIA_CACHE_DIR):
-    """
-    Load or download and load from cache the spectrum of a gaia star, converted to erg/s/cm^2/A
-    """
-    # create cache dir if it does not exist
-    pathlib.Path(GAIA_CACHE_DIR).mkdir(parents=True, exist_ok=True)
-
-    if path.exists(GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv") is True:
-        # read the tables from our cache
-        gaiaflux = Table.read(
-            GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv", format="csv"
-        )
-        gaiawave = Table.read(
-            GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + "_sampling.csv", format="csv"
-        )
-    else:
-        # need to download from Gaia archive
-        CSV_URL = (
-            "https://gea.esac.esa.int/data-server/data?RETRIEVAL_TYPE=XP_CONTINUOUS&ID=Gaia+DR3+"
-            + str(gaiaID)
-            + "&format=CSV&DATA_STRUCTURE=RAW"
-        )
-        FILE = GAIA_CACHE_DIR + "/XP_" + str(gaiaID) + "_RAW.csv"
-
-        with requests.get(CSV_URL, stream=True) as r:
-            r.raise_for_status()
-            if len(r.content) < 2:
-                raise GaiaStarNotFound(f"Gaia DR3 {gaiaID} has no BP-RP spectrum!")
-            with open(FILE, "w") as f:
-                f.write(r.content.decode("utf-8"))
-
-        # convert coefficients to sampled spectrum
-        _, _ = calibrate(
-            FILE,
-            output_path=GAIA_CACHE_DIR,
-            output_file="gaia_spec_" + str(gaiaID),
-            output_format="csv",
-        )
-        # read the flux and wavelength tables
-        gaiaflux = Table.read(
-            GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + ".csv", format="csv"
-        )
-        gaiawave = Table.read(
-            GAIA_CACHE_DIR + "/gaia_spec_" + str(gaiaID) + "_sampling.csv", format="csv"
-        )
-
-    # make numpy arrays from whatever weird objects the Gaia stuff creates
-    wave = numpy.fromstring(gaiawave["pos"][0][1:-1], sep=",") * 10  # in Angstrom
-    flux = (
-        1e7 * 1e-1 * 1e-4 * numpy.fromstring(gaiaflux["flux"][0][1:-1], sep=",")
-    )  # W/s/micron -> in erg/s/cm^2/A
-    return wave, flux
 
 
 def extinctLaSilla(wave):

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -29,7 +29,6 @@ from astropy import units as u
 from astropy.stats import biweight_location, biweight_scale
 from astropy.table import Table
 from astropy.io import fits
-from astroquery.gaia import Gaia
 
 from lmfit import minimize, Parameters
 
@@ -894,16 +893,12 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
     GAIA_CACHE_DIR = "./" if GAIA_CACHE_DIR is None else GAIA_CACHE_DIR
     log.info(f"Using Gaia CACHE DIR '{GAIA_CACHE_DIR}'")
 
-    # Read Calibration GAIA stars table and create index on source_id for quick
-    # record retrieval
-    # https://sdss-wiki.atlassian.net/wiki/spaces/LVM/pages/14460157/Calibration+Stars
-    gaia_stars = Table.read(models_dir + '/lvm-many_Gaia_stars_5-9_ftype_v4-all.fits', format='fits')
-    gaia_stars.add_index('source_id')
-
     # Prepare the spectra
     (w, nns, gaia_ids, fibers, std_spectra_all_bands, normalized_spectra_unconv_all_bands,
      normalized_spectra_all_bands, std_errors_all_bands, lsf_all_bands,
      std_spectra_orig_all_bands, zenith_angles, std_info) = prepare_spec(in_rss, width=width)
+
+    stellar_params = fluxcal.get_std_stellar_params(source_ids=gaia_ids)
 
     # Stitch wavelength arrays in brz together
     wave_b = np.round(w[0],1)
@@ -938,9 +933,6 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
     model_to_gaia_median = []
     best_fit_models = []
     gaia_flux_interpolated = []
-    gaia_Teff = []
-    gaia_logg = []
-    gaia_z = []
     pwv_values, pwv_errors = [], []
     stack_stellar_model, stack_telluric_trans = [], []
 
@@ -1108,31 +1100,12 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
         try:
             gw, gf = fluxcal.get_std_xp_spectrum(gaia_ids[i], cache_dir=GAIA_CACHE_DIR)
             stdflux = np.interp(std_wave_all, gw, gf)  # interpolate to our wavelength grid
-
-            # Try to get stellar parameters from the local table first
-            try:
-                # Used indexed column source_id, See where table was read
-                gaia_rec = gaia_stars.loc[gaia_ids[i]]
-                teff, logg, z = gaia_rec['teff_gspspec'], gaia_rec['logg_gspspec'], gaia_rec['mh_gspspec']
-            except KeyError:
-                # If entry not found in local table, then call external Gaia service
-                job = Gaia.launch_job(f"SELECT teff_gspspec, logg_gspspec, mh_gspspec FROM gaiadr3.astrophysical_parameters WHERE source_id = {gaia_ids[i]} ")
-                r = job.get_results()
-                teff, logg, z = r['teff_gspspec'][0], r['logg_gspspec'][0], r['mh_gspspec'][0]
         except (fluxcal.GaiaStarNotFound, requests.exceptions.HTTPError) as e:
             stdflux = np.full_like(std_wave_all, np.nan)
-            teff, logg, z = np.nan, np.nan, np.nan
             model_to_gaia_median.append(np.nan)
             log.warning(f"Gaia star {gaia_ids[i]} not found: {e}")
         finally:
             gaia_flux_interpolated.append(stdflux)
-            gaia_Teff.append(teff)
-            gaia_logg.append(logg)
-            gaia_z.append(z)
-
-        # Skip star with no Gaia parameters
-        if np.isnan(teff):
-            continue
 
         # Keep Eugenia's implementation for a reference after a minor bug fix
         # (missing GAIA LSF conversion to pixels).
@@ -1169,9 +1142,9 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
         fiber_params = {'i': i, 'fiber_id': fibers[i]}
         gaia_params = {
             'gaia_id': gaia_ids[i],
-            'gaia_Teff': gaia_Teff[i],
-            'gaia_logg': gaia_logg[i],
-            'gaia_z': gaia_z[i]
+            'gaia_Teff': stellar_params.loc[gaia_ids[i], 'teff_gspspec'],
+            'gaia_logg': stellar_params.loc[gaia_ids[i], 'logg_gspspec'],
+            'gaia_z': stellar_params.loc[gaia_ids[i], 'mh_gspspec']
         }
         model_params = {
             'model_name': model_names[best_id],

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -1106,7 +1106,7 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
 
         # load Gaia BP-RP spectrum from cache, or download from webapp, and fit the continuum to Gaia spec
         try:
-            gw, gf = fluxcal.get_gaia_xp_spectrum(gaia_ids[i], cache_dir=GAIA_CACHE_DIR)
+            gw, gf = fluxcal.get_std_xp_spectrum(gaia_ids[i], cache_dir=GAIA_CACHE_DIR)
             stdflux = np.interp(std_wave_all, gw, gf)  # interpolate to our wavelength grid
 
             # Try to get stellar parameters from the local table first
@@ -1706,7 +1706,7 @@ def standard_sensitivity(stds, rss, GAIA_CACHE_DIR, ext, res, plot=False, width=
 
         # load Gaia BP-RP spectrum from cache, or download from webapp
         try:
-            gw, gf = fluxcal.get_gaia_xp_spectrum(gaia_id, cache_dir=GAIA_CACHE_DIR)
+            gw, gf = fluxcal.get_std_xp_spectrum(gaia_id, cache_dir=GAIA_CACHE_DIR)
             stdflux = np.interp(w, gw, gf)  # interpolate to our wavelength grid
         except fluxcal.GaiaStarNotFound as e:
             log.warning(e)
@@ -1833,12 +1833,8 @@ def science_sensitivity(rss, res_sci, ext, GAIA_CACHE_DIR, NSCI_MAX=15, r_spaxel
         m2 = get_z_continuum_mask(obswave)
 
     # get GAIA data, potentially cached
-    r = fluxcal.get_gaia_ids(expnum, ra, dec, lim_mag=13.5, n_ids=NSCI_MAX, cache_dir=GAIA_CACHE_DIR)
-    sampling, calibrated_spectra = fluxcal.get_gaia_xp_spectra(expnum, source_ids=r["source_id"], cache_dir=GAIA_CACHE_DIR)
-    gwave = sampling*10 # to A
-    for i in range(len(calibrated_spectra)):
-        # W/micron/m^2 -> in erg/s/cm^2/A
-        calibrated_spectra.iloc[i].flux *= 100
+    gwave, calibrated_spectra, r = fluxcal.get_tile_xp_spectra(expnum, ra, dec, lim_mag=13.5, n_spectra=NSCI_MAX,
+                                                               return_table=True, convert_to_cgs=True, cache_dir=GAIA_CACHE_DIR)
 
     # read the mean sensitivity curve
     mean_sens = fluxcal.get_mean_sens_curves(os.getenv("LVMCORE_DIR") + "/sensitivity")
@@ -1871,7 +1867,7 @@ def science_sensitivity(rss, res_sci, ext, GAIA_CACHE_DIR, NSCI_MAX=15, r_spaxel
                 log.info(f"dropping gaia star {data['source_id']} in fiber {fib}, multiple stars")
                 continue
             # if we found a single star in a fiber
-            gflux = calibrated_spectra.iloc[i].flux
+            gflux = calibrated_spectra[i]
 
             fibidx = scifibs['fiberid'][fib] - 1
 

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -1106,7 +1106,7 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
 
         # load Gaia BP-RP spectrum from cache, or download from webapp, and fit the continuum to Gaia spec
         try:
-            gw, gf = fluxcal.retrive_gaia_star(gaia_ids[i], GAIA_CACHE_DIR=GAIA_CACHE_DIR)
+            gw, gf = fluxcal.get_gaia_xp_spectrum(gaia_ids[i], cache_dir=GAIA_CACHE_DIR)
             stdflux = np.interp(std_wave_all, gw, gf)  # interpolate to our wavelength grid
 
             # Try to get stellar parameters from the local table first
@@ -1706,7 +1706,7 @@ def standard_sensitivity(stds, rss, GAIA_CACHE_DIR, ext, res, plot=False, width=
 
         # load Gaia BP-RP spectrum from cache, or download from webapp
         try:
-            gw, gf = fluxcal.retrive_gaia_star(gaia_id, GAIA_CACHE_DIR=GAIA_CACHE_DIR)
+            gw, gf = fluxcal.get_gaia_xp_spectrum(gaia_id, cache_dir=GAIA_CACHE_DIR)
             stdflux = np.interp(w, gw, gf)  # interpolate to our wavelength grid
         except fluxcal.GaiaStarNotFound as e:
             log.warning(e)
@@ -1833,8 +1833,8 @@ def science_sensitivity(rss, res_sci, ext, GAIA_CACHE_DIR, NSCI_MAX=15, r_spaxel
         m2 = get_z_continuum_mask(obswave)
 
     # get GAIA data, potentially cached
-    r, calibrated_spectra, sampling = fluxcal.get_XP_spectra(expnum, ra, dec, plot=False, lim_mag=13.5,
-                                                             n_spec=NSCI_MAX, GAIA_CACHE_DIR=GAIA_CACHE_DIR)
+    r = fluxcal.get_gaia_ids(expnum, ra, dec, lim_mag=13.5, n_ids=NSCI_MAX, cache_dir=GAIA_CACHE_DIR)
+    sampling, calibrated_spectra = fluxcal.get_gaia_xp_spectra(expnum, source_ids=r["source_id"], cache_dir=GAIA_CACHE_DIR)
     gwave = sampling*10 # to A
     for i in range(len(calibrated_spectra)):
         # W/micron/m^2 -> in erg/s/cm^2/A

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -197,7 +197,7 @@ def apply_fluxcal(in_rss: str, out_fframe: str, method: str = 'MOD', display_plo
             method = 'SCI'
         # fall back to science field if less than 8 standard stars
         elif (~np.isnan(sens_arr).all(axis=0)).sum() < 8:
-            log.warning(f"{np.isnan(sens_arr).all(axis=0).sum()} good standard fibers")
+            log.warning(f"{(~np.isnan(sens_arr).all(axis=0)).sum()} good standard fibers")
             log.warning("less than 8 good standard fibers, falling back to science field calibration")
             rss.add_header_comment("less than 8 good standard fibers, falling back to science field calibration")
             method = "SCI"

--- a/python/lvmdrp/functions/fluxCalMethod.py
+++ b/python/lvmdrp/functions/fluxCalMethod.py
@@ -10,7 +10,6 @@
 import os
 import time
 import warnings
-import requests
 # from os import listdir
 # from os.path import isfile, join
 import numpy as np
@@ -898,7 +897,10 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
      normalized_spectra_all_bands, std_errors_all_bands, lsf_all_bands,
      std_spectra_orig_all_bands, zenith_angles, std_info) = prepare_spec(in_rss, width=width)
 
-    stellar_params = fluxcal.get_std_stellar_params(source_ids=gaia_ids)
+    # download or load from cache Gaia stellar parameters
+    stellar_params = fluxcal.get_stellar_params(source_ids=gaia_ids)
+    # load Gaia BP-RP spectrum from cache, or download from webapp
+    wave_xp, spectra_xp = fluxcal.get_xp_spectra_from_ids(source_ids=gaia_ids)
 
     # Stitch wavelength arrays in brz together
     wave_b = np.round(w[0],1)
@@ -1096,16 +1098,11 @@ def model_selection(in_rss, GAIA_CACHE_DIR=None, width=3, plot=True):
         # gaia_lsf_rp = np.interp(std_wave_all[mask_wl_rp], gaia_lsf_table_rp['wavelength'], gaia_lsf_table_rp['linewidth'])
         # gaia_lsf = np.concatenate((gaia_lsf_bp, gaia_lsf_rp))
 
-        # load Gaia BP-RP spectrum from cache, or download from webapp, and fit the continuum to Gaia spec
-        try:
-            gw, gf = fluxcal.get_std_xp_spectrum(gaia_ids[i], cache_dir=GAIA_CACHE_DIR)
-            stdflux = np.interp(std_wave_all, gw, gf)  # interpolate to our wavelength grid
-        except (fluxcal.GaiaStarNotFound, requests.exceptions.HTTPError) as e:
-            stdflux = np.full_like(std_wave_all, np.nan)
-            model_to_gaia_median.append(np.nan)
-            log.warning(f"Gaia star {gaia_ids[i]} not found: {e}")
-        finally:
-            gaia_flux_interpolated.append(stdflux)
+        # fit the continuum to Gaia spec
+        gw = wave_xp.copy()
+        gf = spectra_xp.copy()[i]
+        stdflux = np.interp(std_wave_all, gw, gf)  # interpolate to our wavelength grid
+        gaia_flux_interpolated.append(stdflux)
 
         # Keep Eugenia's implementation for a reference after a minor bug fix
         # (missing GAIA LSF conversion to pixels).
@@ -1667,6 +1664,10 @@ def standard_sensitivity(stds, rss, GAIA_CACHE_DIR, ext, res, plot=False, width=
 
     master_sky = rss.eval_master_sky()
 
+    # load Gaia BP-RP spectrum from cache, or download from webapp
+    _, _, gaia_ids, _, _, _ = zip(*stds)
+    wave_xp, spectra_xp = fluxcal.get_xp_spectra_from_ids(source_ids=gaia_ids)
+
     # iterate over standard stars, derive sensitivity curve for each
     for i, s in enumerate(stds):
         nn, fiber, gaia_id, exptime, secz, _ = s  # unpack standard star tuple
@@ -1676,15 +1677,6 @@ def standard_sensitivity(stds, rss, GAIA_CACHE_DIR, ext, res, plot=False, width=
         fibidx = np.where(select)[0]
 
         log.info(f"standard fiber '{fiber}', index '{fibidx}', star '{gaia_id}', exptime '{exptime:.2f}', secz '{secz:.2f}'")
-
-        # load Gaia BP-RP spectrum from cache, or download from webapp
-        try:
-            gw, gf = fluxcal.get_std_xp_spectrum(gaia_id, cache_dir=GAIA_CACHE_DIR)
-            stdflux = np.interp(w, gw, gf)  # interpolate to our wavelength grid
-        except fluxcal.GaiaStarNotFound as e:
-            log.warning(e)
-            rss.add_header_comment(f"Gaia star {gaia_id} not found")
-            continue
 
         # subtract sky spectrum and divide by exptime
         spec = rss._data[fibidx[0], :]
@@ -1743,6 +1735,7 @@ def standard_sensitivity(stds, rss, GAIA_CACHE_DIR, ext, res, plot=False, width=
         # s_gaia = interpolate.make_smoothing_spline(wgood_gaia, sgood_gaia, lam=win)
 
         # divide to find sensitivity and smooth
+        stdflux = np.interp(w, wave_xp, spectra_xp[i])  # interpolate to our wavelength grid
         sens = stdflux / spec
         wgood, sgood = fluxcal.filter_channel(w, sens, 2)
         s = interpolate.make_smoothing_spline(wgood, sgood, lam=1e4)
@@ -1806,7 +1799,7 @@ def science_sensitivity(rss, res_sci, ext, GAIA_CACHE_DIR, NSCI_MAX=15, r_spaxel
         m2 = get_z_continuum_mask(obswave)
 
     # get GAIA data, potentially cached
-    gwave, calibrated_spectra, r = fluxcal.get_tile_xp_spectra(expnum, ra, dec, lim_mag=13.5, n_spectra=NSCI_MAX,
+    gwave, calibrated_spectra, r = fluxcal.get_xp_spectra_from_tile(expnum, ra, dec, lim_mag=13.5, n_spectra=NSCI_MAX,
                                                                return_table=True, convert_to_cgs=True, cache_dir=GAIA_CACHE_DIR)
 
     # read the mean sensitivity curve

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -2060,11 +2060,13 @@ def cache_std_xp_spectra(mjds: Union[int, str, list], ignore_cache: bool = False
                 header = f[0].header
                 expnum = exposure["expnum"]
                 source_ids = list(filter(lambda s: s is not None, header["STD*ID"].values()))
-
+                acquired_stds = list(header["STD*ACQ"].values())
+                total_acquired = sum(acquired_stds)
+                log.info(f"{expnum = } has standard stars metadata and {total_acquired} were acquired")
             # cache corresponding gaia spectra
             if not dry_run:
                 try:
-                    fluxcal.get_std_xp_spectra(source_ids, cache_only=True, cache_dir=gaia_cache_dir, ignore_cache=ignore_cache)
+                    fluxcal.get_xp_spectra_from_ids(source_ids, cache_only=True, cache_dir=gaia_cache_dir, ignore_cache=ignore_cache)
                 except Exception as e:
                     log.error(f"failed caching of Gaia spectra for {expnum = }: {e}")
                     failed_expnums.append(expnum)
@@ -2114,7 +2116,6 @@ def cache_sci_xp_spectra(mjds: Union[int, str, list], min_acquired=999, ignore_c
                     if total_acquired >= min_acquired:
                         log.info(f"{expnum = } has standard stars metadata and {total_acquired} were acquired, skipping")
                         continue
-                    log.info(f"{expnum = } has standard stars metadata and {total_acquired} were acquired")
                 # get exposure parameters
                 ra = header.get("POSCIRA", header.get("TESCIRA"))
                 dec = header.get("POSCIDE", header.get("TESCIDE"))
@@ -2122,7 +2123,7 @@ def cache_sci_xp_spectra(mjds: Union[int, str, list], min_acquired=999, ignore_c
             # cache corresponding gaia spectra
             if not dry_run:
                 try:
-                    fluxcal.get_tile_xp_spectra(expnum, ra, dec, lim_mag=13.5, n_spectra=15, cache_only=True, cache_dir=gaia_cache_dir, ignore_cache=ignore_cache)
+                    fluxcal.get_xp_spectra_from_tile(expnum, ra, dec, lim_mag=13.5, n_spectra=15, cache_only=True, cache_dir=gaia_cache_dir, ignore_cache=ignore_cache)
                 except Exception as e:
                     log.error(f"failed caching of Gaia spectra for {expnum = }: {e}")
                     failed_expnums.append(expnum)

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -2036,7 +2036,45 @@ def create_drpall(drp_version: str = None, overwrite: bool = False) -> None:
     log.info(f"finished converting HDF5 to FITS format in {drpall}")
 
 
-def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, ignore_cache: bool = False, dry_run: bool = False) -> None:
+def cache_std_xp_spectra(mjds: Union[int, str, list], ignore_cache: bool = False, dry_run: bool = False) -> None:
+    log.info("start of Gaia XP spectra caching for science field flux calibration")
+    gaia_cache_dir = os.path.join(os.getenv("LVM_MASTER_DIR"), "gaia_cache")
+    # parse MJDs
+    mjds = parse_mjds(mjds)
+    if isinstance(mjds, int):
+        mjds = [mjds]
+    log.info(f"selecting MJDs: {','.join(map(str, mjds))}")
+
+    for mjd in mjds:
+        # load metadata and filter good quality science frames
+        frames = get_frames_metadata(mjd=mjd)
+        frames.query("imagetyp == 'object' and qaqual == 'GOOD'", inplace=True)
+        frames = frames.drop_duplicates(subset=["expnum"], keep="first")
+
+        failed_expnums = []
+        for exposure in frames.to_dict("records"):
+            log.info(f"going to cache XP spectra for expnum = {exposure['expnum']}")
+            raw_path = path.full("lvm_raw", camspec=exposure["camera"], **exposure)
+            # check for presence of standard stars metadata
+            with fits.open(raw_path) as f:
+                header = f[0].header
+                expnum = exposure["expnum"]
+                source_ids = list(filter(lambda s: s is not None, header["STD*ID"].values()))
+
+            # cache corresponding gaia spectra
+            if not dry_run:
+                try:
+                    fluxcal.get_std_xp_spectra(source_ids, cache_only=True, cache_dir=gaia_cache_dir, ignore_cache=ignore_cache)
+                except Exception as e:
+                    log.error(f"failed caching of Gaia spectra for {expnum = }: {e}")
+                    failed_expnums.append(expnum)
+                    continue
+
+    # summarize run
+    log.info(f"cached Gaia XP metadata for {len(frames) - len(failed_expnums)} exposures, with {len(failed_expnums)} fails, {failed_expnums = }")
+
+
+def cache_sci_xp_spectra(mjds: Union[int, str, list], min_acquired=999, ignore_cache: bool = False, dry_run: bool = False) -> None:
     """Caches Gaia XP spectra for science field calibration
 
     Parameters
@@ -2064,6 +2102,7 @@ def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, ignore_cac
 
         failed_expnums = []
         for exposure in frames.to_dict("records"):
+            log.info(f"going to cache XP spectra for expnum = {exposure['expnum']}")
             raw_path = path.full("lvm_raw", camspec=exposure["camera"], **exposure)
             # check for presence of standard stars metadata
             with fits.open(raw_path) as f:

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -2085,7 +2085,8 @@ def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, dry_run: b
             log.info(f"going to download 15 field stars spectra with G<13.5 around {ra = }, {dec = } for {expnum = }")
             if not dry_run:
                 try:
-                    fluxcal.get_XP_spectra(expnum, ra, dec, plot=False, lim_mag=13.5, n_spec=15, GAIA_CACHE_DIR=gaia_cache_dir)
+                    gaia_table = fluxcal.get_gaia_ids(expnum, ra, dec, lim_mag=13.5, n_ids=15, cache_dir=gaia_cache_dir)
+                    fluxcal.get_gaia_xp_spectra(expnum, source_ids=gaia_table["source_id"], cache_dir=gaia_cache_dir)
                 except Exception as e:
                     log.error(f"failed caching of Gaia spectra for {expnum = }: {e}")
                     failed_expnums.append(expnum)

--- a/python/lvmdrp/main.py
+++ b/python/lvmdrp/main.py
@@ -2036,7 +2036,7 @@ def create_drpall(drp_version: str = None, overwrite: bool = False) -> None:
     log.info(f"finished converting HDF5 to FITS format in {drpall}")
 
 
-def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, dry_run: bool = False) -> None:
+def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, ignore_cache: bool = False, dry_run: bool = False) -> None:
     """Caches Gaia XP spectra for science field calibration
 
     Parameters
@@ -2050,7 +2050,6 @@ def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, dry_run: b
     """
     log.info("start of Gaia XP spectra caching for science field flux calibration")
     gaia_cache_dir = os.path.join(os.getenv("LVM_MASTER_DIR"), "gaia_cache")
-    os.makedirs(gaia_cache_dir, exist_ok=True)
     # parse MJDs
     mjds = parse_mjds(mjds)
     if isinstance(mjds, int):
@@ -2082,18 +2081,16 @@ def cache_gaia_spectra(mjds: Union[int, str, list], min_acquired=999, dry_run: b
                 dec = header.get("POSCIDE", header.get("TESCIDE"))
 
             # cache corresponding gaia spectra
-            log.info(f"going to download 15 field stars spectra with G<13.5 around {ra = }, {dec = } for {expnum = }")
             if not dry_run:
                 try:
-                    gaia_table = fluxcal.get_gaia_ids(expnum, ra, dec, lim_mag=13.5, n_ids=15, cache_dir=gaia_cache_dir)
-                    fluxcal.get_gaia_xp_spectra(expnum, source_ids=gaia_table["source_id"], cache_dir=gaia_cache_dir)
+                    fluxcal.get_tile_xp_spectra(expnum, ra, dec, lim_mag=13.5, n_spectra=15, cache_only=True, cache_dir=gaia_cache_dir, ignore_cache=ignore_cache)
                 except Exception as e:
                     log.error(f"failed caching of Gaia spectra for {expnum = }: {e}")
                     failed_expnums.append(expnum)
                     continue
 
     # summarize run
-    log.info(f"cached metadata for {len(frames) - len(failed_expnums)} exposures, with {len(failed_expnums)} fails, {failed_expnums = }")
+    log.info(f"cached Gaia XP metadata for {len(frames) - len(failed_expnums)} exposures, with {len(failed_expnums)} fails, {failed_expnums = }")
 
 
 def reduce_calib_frame(row: dict):


### PR DESCRIPTION
This PR implements a number of improvements for fetching and caching Gaia XP spectra for standard and science field  flux calibration methods. Main changes are:

- Downloading Gaia XP spectra coefficients through DR3 mirror @ AIP (avoiding `astroquery` and `gaiaxpy`)
- Homogeneous file format of storing XP spectra in cache directory
- Improved caching of XP spectra
- Implemented/improved CLI for caching standard/science field XP spectra
- Improved high-level routines in flux calibration for 
- Refactored all related code for better maintenance

These changes imply a speed-up of >3x when downloading XP spectra. Since we are avoiding `gaiaxpy` and `astroquery` these changes should also solve the missing `temp_X_Y.Z` directory issue.