### PR TITLE
Fixffactors

### DIFF
--- a/bin/drp
+++ b/bin/drp
@@ -25,7 +25,7 @@ from lvmdrp.utils.cluster import run_cluster, run_cluster_cals
 from lvmdrp.functions.run_calseq import (
     CALIBRATION_EPOCHS_PATH,
     COUNTS_THRESHOLDS,
-    load_calibration_epochs,
+    load_epochs_file,
     validate_calibration_epochs,
     detrend_calibrations,
     reduce_nightly_sequence,
@@ -348,7 +348,7 @@ def longterm(mjd, mjd_list, mjd_range, from_epochs, epochs_file, reject_cr,
         mjds = [mjds]
     # if no MJD, get fiducial calibration epochs
     if from_epochs or mjds is None:
-        epochs = load_calibration_epochs(epochs_path=epochs_file, filter_by=mjds)
+        epochs = load_epochs_file(epochs_kind="calibration", epochs_path=epochs_file, filter_by_mjds=mjds)
         mjds = sorted(list(epochs.keys()))
 
     # run reduction sequence
@@ -521,7 +521,7 @@ def fiberflats(mjd, mjd_list, mjd_range, epochs_file, channels, skip_sequence_se
         mjds = [mjds]
     mjds = [int(mjd) for mjd in mjds]
 
-    epochs = load_calibration_epochs(epochs_path=epochs_file, verbose=False)
+    epochs = load_epochs_file(epochs_kind="calibration", epochs_path=epochs_file, verbose=False)
     mjd_epochs = sorted(list(epochs.keys())) + [99999]
 
     cals_mjd = {mjd: mjd_epochs[i] for mjd in mjds for i in range(len(mjd_epochs) - 1) if mjd >= mjd_epochs[i] and mjd < mjd_epochs[i+1]}
@@ -557,7 +557,7 @@ def create_tag(mjd, mjd_list, mjd_range, from_epochs, epochs_file, version, dry_
         mjds = [mjds]
     # if no MJD, get fiducial calibration epochs
     if from_epochs or mjds is None:
-        epochs = load_calibration_epochs(epochs_path=epochs_file, filter_by=mjds, verbose=False)
+        epochs = load_epochs_file(epochs_kind="calibration", epochs_path=epochs_file, filter_by_mjds=mjds, verbose=False)
         mjds = sorted(list(epochs.keys()))
 
     for mjd in mjds:
@@ -677,7 +677,7 @@ def cluster_calibs(mjd_list, mjd_range, from_epochs, epochs_file, routine, nodes
     mjds = parse_mjds(mjd=mjd_list or mjd_range or None)
     # if no MJD, get fiducial calibration epochs
     if from_epochs or mjds is None:
-        epochs = load_calibration_epochs(epochs_path=epochs_file, filter_by=mjds, verbose=verbose)
+        epochs = load_epochs_file(epochs_kind="calibration", epochs_path=epochs_file, filter_by_mjds=mjds, verbose=verbose)
         mjds = sorted(list(epochs.keys()))
 
     run_cluster_cals(mjds, from_epochs=from_epochs, nodes=nodes, ppn=ppn, walltime=walltime, alloc=alloc, submit=submit,

--- a/bin/drp
+++ b/bin/drp
@@ -500,13 +500,14 @@ def ffactors_experiment(mjd, mjd_list, mjd_range, drpver, channel, b_skyline, r_
 @click.option('-l', '--mjd-list', type=IntListType(), help='a list of specific MJDs to reduce')
 @click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
 @click.option('--epochs-file', type=str, default=None, help="Path to a calibrations epoch file")
+@click.option('--channels', type=str, default="brz", help="Spectrograph channels that will be analysed")
 @click.option('--skip-sequence-selection', is_flag=True, default=False, help='skip selection of calibration sequence, select all matching flavor instead')
 @click.option('--skip-combination', is_flag=True, default=False, help='skip combining calibrations into master frame')
 @click.option('-s', '--skip-done', is_flag=True, default=False, help='flag to skip reduction steps that have already been done')
 @click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running reductions")
 @cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
 @cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
-def fiberflats(mjd, mjd_list, mjd_range, epochs_file, skip_sequence_selection, skip_combination, skip_done, dry_run):
+def fiberflats(mjd, mjd_list, mjd_range, epochs_file, channels, skip_sequence_selection, skip_combination, skip_done, dry_run):
 
     # parse MJDs
     mjds = parse_mjds(mjd=mjd or mjd_list or mjd_range or None)
@@ -527,6 +528,7 @@ def fiberflats(mjd, mjd_list, mjd_range, epochs_file, skip_sequence_selection, s
         create_twilight_fiberflats(
             mjd=mjd,
             cals_mjd=cals_mjd[mjd],
+            channels=channels,
             skip_sequence_selection=skip_sequence_selection,
             skip_combination=skip_combination,
             skip_done=skip_done,

--- a/bin/drp
+++ b/bin/drp
@@ -10,7 +10,7 @@ from typing import List
 
 import click
 import cloup
-from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
+from cloup.constraints import mutually_exclusive, RequireExactly
 
 import bottleneck as bn
 from astropy.stats import biweight_location
@@ -450,12 +450,20 @@ def fiberflat_corrections(mjd, science_mjds, science_expnums, force_correction, 
 @click.option('--label', type=str, help='label for the output tables')
 @click.option('--table-dir', type=str, help='directory path where the output tables will be stored')
 @click.option('--overwrite', is_flag=True, default=False, help='overwrite existing output tables')
-@click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running experiment")
+@click.option('--use-untagged-cals', is_flag=True, default=False, help='use fiber flat field from the untagged (not sandbox) directory')
+@click.option('--version-cals', type=str, help='fiber flat field version to use if --use-untagged-cals is given')
+@click.option("--dry-run", is_flag=True, default=False, help="shows useful information about the current setup without actually running experiment")
 @cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
 @cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
 def ffactors_experiment(mjd, mjd_list, mjd_range, drpver, channel, b_skyline, r_skyline, z_skyline, dwave,
                         fiber_radius, oversampling_factor, quantiles, groupby, coadd_method, norm_stat,
-                        fit_gradient, label, table_dir, overwrite, dry_run):
+                        fit_gradient, label, table_dir, overwrite, use_untagged_cals, version_cals, dry_run):
+
+    if use_untagged_cals and version_cals is None:
+        raise click.UsageError(
+            "--version-cals is required when --use-untagged-cals is used"
+        )
+
     STATS = {
         "mean": bn.nanmean,
         "median": bn.nanmedian,
@@ -475,7 +483,9 @@ def ffactors_experiment(mjd, mjd_list, mjd_range, drpver, channel, b_skyline, r_
                           fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
                           quantiles=quantiles, groupby=groupby, coadd_method=coadd_method,
                           norm_stat=STATS[norm_stat], fit_gradient=fit_gradient, label=label,
-                          write_table=True, table_dir=table_dir, overwrite=overwrite, dry_run=dry_run)
+                          write_table=True, table_dir=table_dir, overwrite=overwrite,
+                          use_untagged_cals=use_untagged_cals, version_cals=version_cals,
+                          dry_run=dry_run)
 
 
 

--- a/bin/drp
+++ b/bin/drp
@@ -12,8 +12,11 @@ import click
 import cloup
 from cloup.constraints import mutually_exclusive, RequireExactly, IsSet, If
 
-from lvmdrp.core.constants import CALIBRATION_MAPPINGS, CALIBRATION_TYPES, LVM_REFERENCE_COLUMN
-from lvmdrp import __version__ as drpver
+import bottleneck as bn
+from astropy.stats import biweight_location
+
+from lvmdrp.core.constants import CALIBRATION_MAPPINGS, CALIBRATION_TYPES, LVM_REFERENCE_COLUMN, SKYLINES_FIBERFLAT
+from lvmdrp import path, __version__ as drpver
 from lvmdrp.main import run_drp, reduce_file, check_daily_mjd, parse_mjds, read_expfile, create_drpall, cache_std_xp_spectra, cache_sci_xp_spectra
 from lvmdrp.functions.skyMethod import configureSkyModel_drp
 from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
@@ -32,7 +35,8 @@ from lvmdrp.functions.run_calseq import (
     create_imagetyp_hdrfix,
     create_qaqual_bad_hdrfix,
     tag_longterm_calibrations,
-    create_fiberflats_corrections)
+    create_fiberflats_corrections,
+    _measure_ffactors)
 
 from sdss_access import Access
 
@@ -411,6 +415,9 @@ def nightly(mjd, mjd_list, mjd_range, reject_cr,
             dry_run=dry_run)
 
 
+# TODO: this command will create an average flat field factor correction out of a set of science frame
+#       I need to refactor this to allow for a custom selection of science exposures and account for
+#       calibration epochs
 @cli.command('fiberflat-corrections', short_help='Run fiberflat skyline correction using science frames', context_settings=dict(show_default=True))
 @click.option('-m', '--mjd', type=int, required=True, help='an MJD for which fiberflats will be corrected')
 @click.option('-l', '--science-mjds', type=IntListType(), required=True, help='a list of specific MJDs to reduce')
@@ -420,6 +427,56 @@ def nightly(mjd, mjd_list, mjd_range, reject_cr,
 @click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running reductions")
 def fiberflat_corrections(mjd, science_mjds, science_expnums, force_correction, skip_done, dry_run):
     create_fiberflats_corrections(cals_mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums, force_correction=force_correction, skip_done=skip_done, dry_run=dry_run)
+
+
+
+@cli.command('ffactors-experiment', short_help='Run a fiber flat-field factor experiment with given parameters', context_settings=dict(show_default=True))
+@click.option('-m', '--mjd', type=int, help='an MJD to reduce')
+@click.option('-l', '--mjd-list', type=IntListType(), help='a list of specific MJDs to reduce')
+@click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
+@click.option('--drpver', type=str, help='Version of the science frame reductions to use for factor measurements')
+@click.option('--channel', type=click.Choice("brz"), default="b", help='channel for which factors will be measured')
+@click.option('--b-skyline', type=float, default=SKYLINES_FIBERFLAT["b"], help='sky line in b-channel')
+@click.option('--r-skyline', type=float, default=SKYLINES_FIBERFLAT["r"], help='sky line in r-channel')
+@click.option('--z-skyline', type=float, default=SKYLINES_FIBERFLAT["z"], help='sky line in z-channel')
+@click.option('--dwave', type=float, default=20.0, help='width of the wavelength window around the sky line in Angstroms')
+@click.option('--fiber-radius', type=float, default=0.01, help='fiber radius in pixels')
+@click.option('--oversampling-factor', type=int, default=100, help='oversampling factor used when fitting the sky line')
+@click.option('--quantiles', type=click.Tuple([float, float]), nargs=2, default=(5.0, 97.0), help='quantiles used to reject contaminated fibers')
+@click.option('--groupby', type=click.Choice(["spec", "quad"]), default="spec", help='type of fiber grouping to use')
+@click.option('--coadd-method', type=click.Choice(["fit", "average", "integrate"]), default="fit", help='type of pixel coadding performed around the sky line')
+@click.option('--norm-stat', type=click.Choice(["biweight", "mean", "median"]), default="biweight", help='type of normalization to calculate the factors')
+@click.option('--fit-gradient', is_flag=True, default=False, help='flag to allow for IFU gradient fitting')
+@click.option('--label', type=str, help='label for the output tables')
+@click.option('--table-dir', type=str, help='directory path where the output tables will be stored')
+@click.option('--overwrite', is_flag=True, default=False, help='overwrite existing output tables')
+@click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running experiment")
+@cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
+@cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
+def ffactors_experiment(mjd, mjd_list, mjd_range, drpver, channel, b_skyline, r_skyline, z_skyline, dwave,
+                        fiber_radius, oversampling_factor, quantiles, groupby, coadd_method, norm_stat,
+                        fit_gradient, label, table_dir, overwrite, dry_run):
+    STATS = {
+        "mean": bn.nanmean,
+        "median": bn.nanmedian,
+        "biweight": lambda x: biweight_location(x, ignore_nan=True)
+    }
+
+    mjds = parse_mjds(mjd=mjd or mjd_list or mjd_range or None)
+    if mjds is None:
+        root = pathlib.Path(os.environ["LVM_SPECTRO_REDUX"]) / drpver
+        mjds = set(p.parts[-3] for p in root.glob("*XX/*/*/ancillary/lvm-wobject-?-????????.fits"))
+    if mjds is not None and not isinstance(mjds, (list, tuple, set)):
+        mjds = [mjds]
+
+    sky_lines = {"b": b_skyline, "r": r_skyline, "z": z_skyline}
+    for mjd in mjds:
+        _measure_ffactors(int(mjd), drpver=drpver, channel=channel, sky_lines=sky_lines, dwave=dwave,
+                          fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                          quantiles=quantiles, groupby=groupby, coadd_method=coadd_method,
+                          norm_stat=STATS[norm_stat], fit_gradient=fit_gradient, label=label,
+                          write_table=True, table_dir=table_dir, overwrite=overwrite, dry_run=dry_run)
+
 
 
 @click.command('create-tag', short_help='Create a tag for long-term calibrations', context_settings=dict(show_default=True))
@@ -547,7 +604,7 @@ def qaqual_bad_hdrfix(mjd, mjd_list, mjd_range, expnum, expnum_list, expnum_rang
 @click.option('-r', '--mjd-range', type=str, default=None, help='a range of MJDs to reduce')
 @click.option('--from-epochs', is_flag=True, default=False, help="Use fiducial or given epochs file to produce long-term calibrations")
 @click.option('--epochs-file', type=str, default=None, help="Path to a calibrations epoch file")
-@click.option('--routine', type=click.Choice(["detrend", "long-term", "nightly"]), default="long-term", help="run detrend, long-term or nightly calibrations only")
+@click.option('--routine', type=click.Choice(["detrend", "long-term", "nightly", "ffactors-experiment"]), default="long-term", help="run detrend, long-term, nightly or ffactors-experiment calibrations only")
 @click.option('-n', '--nodes', type=int, default=2, help='the number of nodes to use')
 @click.option('-p', '--ppn', type=int, default=64, help='the number of CPU cores to use per node')
 @click.option('-w', '--walltime', type=str, default="24:00:00", help='the time for which the job is allowed to run')
@@ -582,6 +639,7 @@ calibrations.add_command(detrend)
 calibrations.add_command(longterm)
 calibrations.add_command(nightly)
 calibrations.add_command(fiberflat_corrections)
+calibrations.add_command(ffactors_experiment)
 calibrations.add_command(cluster_calibs)
 calibrations.add_command(create_tag)
 cli.add_command(calibrations)

--- a/bin/drp
+++ b/bin/drp
@@ -35,6 +35,7 @@ from lvmdrp.functions.run_calseq import (
     create_imagetyp_hdrfix,
     create_qaqual_bad_hdrfix,
     tag_longterm_calibrations,
+    create_twilight_fiberflats,
     create_fiberflats_corrections,
     _measure_ffactors)
 
@@ -494,6 +495,43 @@ def ffactors_experiment(mjd, mjd_list, mjd_range, drpver, channel, b_skyline, r_
                           dry_run=dry_run)
 
 
+@cli.command('fiberflats', short_help='Run twilight fiberflat reductions', context_settings=dict(show_default=True))
+@click.option('-m', '--mjd', type=int, help='an MJD to reduce')
+@click.option('-l', '--mjd-list', type=IntListType(), help='a list of specific MJDs to reduce')
+@click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
+@click.option('--epochs-file', type=str, default=None, help="Path to a calibrations epoch file")
+@click.option('--skip-sequence-selection', is_flag=True, default=False, help='skip selection of calibration sequence, select all matching flavor instead')
+@click.option('--skip-combination', is_flag=True, default=False, help='skip combining calibrations into master frame')
+@click.option('-s', '--skip-done', is_flag=True, default=False, help='flag to skip reduction steps that have already been done')
+@click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running reductions")
+@cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
+@cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
+def fiberflats(mjd, mjd_list, mjd_range, epochs_file, skip_sequence_selection, skip_combination, skip_done, dry_run):
+
+    # parse MJDs
+    mjds = parse_mjds(mjd=mjd or mjd_list or mjd_range or None)
+    if mjds is None:
+        raise click.UsageError("One of --mjd, --mjd-list, or --mjd-range is required.")
+
+    if not isinstance(mjds, (list, tuple)):
+        mjds = [mjds]
+    mjds = [int(mjd) for mjd in mjds]
+
+    epochs = load_calibration_epochs(epochs_path=epochs_file, verbose=False)
+    mjd_epochs = sorted(list(epochs.keys())) + [99999]
+
+    cals_mjd = {mjd: mjd_epochs[i] for mjd in mjds for i in range(len(mjd_epochs) - 1) if mjd >= mjd_epochs[i] and mjd < mjd_epochs[i+1]}
+
+    # run reduction sequence
+    for mjd in mjds:
+        create_twilight_fiberflats(
+            mjd=mjd,
+            cals_mjd=cals_mjd[mjd],
+            skip_sequence_selection=skip_sequence_selection,
+            skip_combination=skip_combination,
+            skip_done=skip_done,
+            dry_run=dry_run)
+
 
 @click.command('create-tag', short_help='Create a tag for long-term calibrations', context_settings=dict(show_default=True))
 @click.option('-m', '--mjd', type=int, help='an MJD to reduce')
@@ -620,7 +658,7 @@ def qaqual_bad_hdrfix(mjd, mjd_list, mjd_range, expnum, expnum_list, expnum_rang
 @click.option('-r', '--mjd-range', type=str, default=None, help='a range of MJDs to reduce')
 @click.option('--from-epochs', is_flag=True, default=False, help="Use fiducial or given epochs file to produce long-term calibrations")
 @click.option('--epochs-file', type=str, default=None, help="Path to a calibrations epoch file")
-@click.option('--routine', type=click.Choice(["detrend", "long-term", "nightly", "ffactors-experiment"]), default="long-term", help="run detrend, long-term, nightly or ffactors-experiment calibrations only")
+@click.option('--routine', type=click.Choice(["detrend", "long-term", "nightly", "ffactors-experiment", "fiberflats"]), default="long-term", help="run detrend, long-term, nightly, ffactors-experiment or fiberflats calibrations only")
 @click.option('-n', '--nodes', type=int, default=2, help='the number of nodes to use')
 @click.option('-p', '--ppn', type=int, default=64, help='the number of CPU cores to use per node')
 @click.option('-w', '--walltime', type=str, default="24:00:00", help='the time for which the job is allowed to run')
@@ -654,6 +692,7 @@ calibrations.add_command(detect_shifts)
 calibrations.add_command(detrend)
 calibrations.add_command(longterm)
 calibrations.add_command(nightly)
+calibrations.add_command(fiberflats)
 calibrations.add_command(fiberflat_corrections)
 calibrations.add_command(ffactors_experiment)
 calibrations.add_command(cluster_calibs)

--- a/bin/drp
+++ b/bin/drp
@@ -430,10 +430,13 @@ def nightly(mjd, mjd_list, mjd_range, reject_cr,
 @click.option('-l', '--science-mjds', type=IntListType(), required=True, help='a list of specific MJDs to reduce')
 @click.option('-e', '--science-expnums', type=IntListType(), default=None, help='a list of specific exposure numbers to reduce')
 @click.option('--force-correction', is_flag=True, default=False, help='flag to force correction even if has been already done')
+@click.option('--undo-correction', is_flag=True, default=False, help='flag to undo correction if already applied')
 @click.option('-s', '--skip-done', is_flag=True, default=False, help='flag to skip reduction steps that have already been done')
 @click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running reductions")
-def fiberflat_corrections(mjd, science_mjds, science_expnums, force_correction, skip_done, dry_run):
-    create_fiberflats_corrections(cals_mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums, force_correction=force_correction, skip_done=skip_done, dry_run=dry_run)
+def fiberflat_corrections(mjd, science_mjds, science_expnums, force_correction, undo_correction, skip_done, dry_run):
+    create_fiberflats_corrections(cals_mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums,
+                                  force_correction=force_correction, undo_correction=undo_correction,
+                                  skip_done=skip_done, dry_run=dry_run)
 
 
 

--- a/bin/drp
+++ b/bin/drp
@@ -16,7 +16,7 @@ import bottleneck as bn
 from astropy.stats import biweight_location
 
 from lvmdrp.core.constants import CALIBRATION_MAPPINGS, CALIBRATION_TYPES, LVM_REFERENCE_COLUMN, SKYLINES_FIBERFLAT
-from lvmdrp import path, __version__ as drpver
+from lvmdrp import __version__ as drpver
 from lvmdrp.main import run_drp, reduce_file, check_daily_mjd, parse_mjds, read_expfile, create_drpall, cache_std_xp_spectra, cache_sci_xp_spectra
 from lvmdrp.functions.skyMethod import configureSkyModel_drp
 from lvmdrp.utils.metadata import get_frames_metadata, get_master_metadata
@@ -37,12 +37,13 @@ from lvmdrp.functions.run_calseq import (
     tag_longterm_calibrations,
     create_twilight_fiberflats,
     create_fiberflats_corrections,
-    _measure_ffactors)
+    measure_fiberflat_factors)
 
 from sdss_access import Access
 
 
 calibration_types = set(CALIBRATION_TYPES) - {"bias", "dome"}
+CALIBRATION_SCRIPTS = ["detrend", "long-term", "nightly", "ffactors-experiment", "fiberflats"]
 
 
 class StrListType(click.ParamType):
@@ -422,22 +423,38 @@ def nightly(mjd, mjd_list, mjd_range, reject_cr,
             dry_run=dry_run)
 
 
-# TODO: this command will create an average flat field factor correction out of a set of science frame
-#       I need to refactor this to allow for a custom selection of science exposures and account for
-#       calibration epochs
 @cli.command('fiberflat-corrections', short_help='Run fiberflat skyline correction using science frames', context_settings=dict(show_default=True))
-@click.option('-m', '--mjd', type=int, required=True, help='an MJD for which fiberflats will be corrected')
-@click.option('-l', '--science-mjds', type=IntListType(), required=True, help='a list of specific MJDs to reduce')
-@click.option('-e', '--science-expnums', type=IntListType(), default=None, help='a list of specific exposure numbers to reduce')
-@click.option('--force-correction', is_flag=True, default=False, help='flag to force correction even if has been already done')
+@click.option('-m', '--mjd', type=int, help='an MJD for which fiberflats will be corrected')
+@click.option('-l', '--mjd-list', type=IntListType(), help='a list of specific MJDs to reduce')
+@click.option('-r', '--mjd-range', type=str, help='a range of MJDs to reduce')
+@click.option('--channels', type=str, default="brz", help="Spectrograph channels that will be analysed")
+@click.option('--calibration-epochs-file', type=str, default=None, help='Path to a calibrations epoch file')
+@click.option('--ffactor-epochs-file', type=str, default=None, help="Path to a fiber flat factors epoch file")
 @click.option('--undo-correction', is_flag=True, default=False, help='flag to undo correction if already applied')
 @click.option('-s', '--skip-done', is_flag=True, default=False, help='flag to skip reduction steps that have already been done')
 @click.option("--dry-run", is_flag=True, default=False, help="Shows useful information about the current setup without actually running reductions")
-def fiberflat_corrections(mjd, science_mjds, science_expnums, force_correction, undo_correction, skip_done, dry_run):
-    create_fiberflats_corrections(cals_mjd=mjd, science_mjds=science_mjds, science_expnums=science_expnums,
-                                  force_correction=force_correction, undo_correction=undo_correction,
-                                  skip_done=skip_done, dry_run=dry_run)
+@cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
+@cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
+def fiberflat_corrections(mjd, mjd_list, mjd_range, channels, calibration_epochs_file, ffactor_epochs_file,
+                          undo_correction, skip_done, dry_run):
 
+    # parse MJDs
+    mjds = parse_mjds(mjd=mjd or mjd_list or mjd_range or None)
+    if mjds is None:
+        raise click.UsageError("One of --mjd, --mjd-list, or --mjd-range is required.")
+
+    if not isinstance(mjds, (list, tuple)):
+        mjds = [mjds]
+    mjds = [int(mjd) for mjd in mjds]
+
+    # require either both epoch files or sience-mjds/expnums or twilight-mjds/expnums
+    calibration_epochs = load_epochs_file(epochs_kind="calibration", epochs_path=calibration_epochs_file, verbose=False)
+    ffactor_epochs = load_epochs_file(epochs_kind="ffactor", epochs_path=ffactor_epochs_file, verbose=False)
+
+    for channel in channels:
+        for mjd in mjds:
+            create_fiberflats_corrections(mjd=mjd, channel=channel, ffactor_epochs=ffactor_epochs, calibration_epochs=calibration_epochs,
+                                          skip_done=skip_done, undo_correction=undo_correction, dry_run=dry_run)
 
 
 @cli.command('ffactors-experiment', short_help='Run a fiber flat-field factor experiment with given parameters', context_settings=dict(show_default=True))
@@ -489,13 +506,13 @@ def ffactors_experiment(mjd, mjd_list, mjd_range, drpver, channel, b_skyline, r_
 
     sky_lines = {"b": b_skyline, "r": r_skyline, "z": z_skyline}
     for mjd in mjds:
-        _measure_ffactors(int(mjd), drpver=drpver, channel=channel, sky_lines=sky_lines, dwave=dwave,
-                          fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
-                          quantiles=quantiles, groupby=groupby, coadd_method=coadd_method,
-                          norm_stat=STATS[norm_stat], fit_gradient=fit_gradient, label=label,
-                          write_table=True, table_dir=table_dir, overwrite=overwrite,
-                          use_untagged_cals=use_untagged_cals, version_cals=version_cals,
-                          dry_run=dry_run)
+        measure_fiberflat_factors(int(mjd), drpver=drpver, channel=channel, sky_cwaves=sky_lines, dwave=dwave,
+                                  fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                                  quantiles=quantiles, groupby=groupby, coadd_method=coadd_method,
+                                  norm_stat=STATS[norm_stat], fit_gradient=fit_gradient, label=label,
+                                  write_table=True, table_dir=table_dir, overwrite=overwrite,
+                                  use_untagged_cals=use_untagged_cals, version_cals=version_cals,
+                                  dry_run=dry_run)
 
 
 @cli.command('fiberflats', short_help='Run twilight fiberflat reductions', context_settings=dict(show_default=True))
@@ -663,7 +680,7 @@ def qaqual_bad_hdrfix(mjd, mjd_list, mjd_range, expnum, expnum_list, expnum_rang
 @click.option('-r', '--mjd-range', type=str, default=None, help='a range of MJDs to reduce')
 @click.option('--from-epochs', is_flag=True, default=False, help="Use fiducial or given epochs file to produce long-term calibrations")
 @click.option('--epochs-file', type=str, default=None, help="Path to a calibrations epoch file")
-@click.option('--routine', type=click.Choice(["detrend", "long-term", "nightly", "ffactors-experiment", "fiberflats"]), default="long-term", help="run detrend, long-term, nightly, ffactors-experiment or fiberflats calibrations only")
+@click.option('--routine', type=click.Choice(CALIBRATION_SCRIPTS), default="long-term", help="run detrend, long-term, nightly, ffactors-experiment or fiberflats calibrations only")
 @click.option('-n', '--nodes', type=int, default=2, help='the number of nodes to use')
 @click.option('-p', '--ppn', type=int, default=64, help='the number of CPU cores to use per node')
 @click.option('-w', '--walltime', type=str, default="24:00:00", help='the time for which the job is allowed to run')

--- a/bin/drp
+++ b/bin/drp
@@ -310,6 +310,8 @@ def detrend(mjd, mjd_list, mjd_range, calibration, dry_run, skip_done):
 @click.option('--from-epochs', is_flag=True, default=False, help="Use fiducial or given epochs file to produce long-term calibrations")
 @click.option('--epochs-file', type=str, default=None, help="Path to a calibrations epoch file")
 @click.option('-cr', '--reject-cr', is_flag=True, default=False, help='flag to run cosmic rays rejection')
+@click.option('--skip-sequence-selection', is_flag=True, default=False, help='skip selection of calibration sequence, select all matching flavor instead')
+@click.option('--skip-combination', is_flag=True, default=False, help='skip combining calibrations into master frame')
 @click.option('-b', '--skip-bias', is_flag=True, default=False, help='skip bias calibrations')
 @click.option('-t', '--skip-trace', is_flag=True, default=False, help='skip fiber traces')
 @click.option('-w', '--skip-wavelength', is_flag=True, default=False, help='skip wavelength calibrations')
@@ -326,6 +328,7 @@ def detrend(mjd, mjd_list, mjd_range, calibration, dry_run, skip_done):
 @cloup.constraint(mutually_exclusive, ['mjd', 'mjd_list', 'mjd_range'])
 @cloup.constraint(RequireExactly(1), ['mjd', 'mjd_list', 'mjd_range'])
 def longterm(mjd, mjd_list, mjd_range, from_epochs, epochs_file, reject_cr,
+             skip_sequence_selection, skip_combination,
              skip_bias, skip_trace, skip_wavelength,
              skip_dome, skip_twilight,
              ldls_threshold, qrtz_threshold,
@@ -355,7 +358,10 @@ def longterm(mjd, mjd_list, mjd_range, from_epochs, epochs_file, reject_cr,
             only_cals=only_cals,
             counts_thresholds={"ldls": ldls_threshold, "quartz": qrtz_threshold},
             cent_guess_ncolumns=cent_ncolumns, trace_full_ncolumns=full_ncolumns,
-            extract_metadata=extract_md, skip_done=skip_done,
+            extract_metadata=extract_md,
+            skip_sequence_selection=skip_sequence_selection,
+            skip_combination=skip_combination,
+            skip_done=skip_done,
             keep_ancillary=not clean_ancillary,
             dry_run=dry_run)
 

--- a/python/lvmdrp/core/fit_profile.py
+++ b/python/lvmdrp/core/fit_profile.py
@@ -51,7 +51,7 @@ def polyval2d(x, y, m):
         z += a * x ** i * y ** j
     return z
 
-def gaussians(pars, x, alpha=2.3, collapse=True):
+def gaussians(pars, x, alpha=2, collapse=True):
     """Gaussian models for multiple components"""
     y = pars[0][:, None] * numpy.exp(-0.5 * numpy.abs((x[None, :] - pars[1][:, None]) / pars[2][:, None]) ** alpha) / (pars[2][:, None] * fact)
     if not collapse:
@@ -135,7 +135,7 @@ def oversample(x, oversampling_factor):
 
 def pixelate(x, models, oversampling_factor):
     models_bins = models.reshape((models.shape[0], models.shape[1]//oversampling_factor, oversampling_factor))
-    models_pixelated = integrate.trapezoid(models_bins, dx=x[1]-x[0], axis=2)
+    models_pixelated = bn.nanmean(models_bins, axis=2)
     return models_pixelated
 
 def update_params(func):
@@ -373,7 +373,10 @@ class Profile1D:
 
     def _fwhms(self, x):
         centroids = self._pars.get("centroids", self._fixed.get("centroids"))
-        half_max = self(centroids) / 2
+        x_centroids = numpy.array(list(set(x.tolist() + centroids.tolist())))
+        x_centroids = numpy.sort(x_centroids)
+        icentroids = numpy.where(x_centroids == centroids)
+        half_max = self(x_centroids)[icentroids] / 2
         if x is None:
             fwhms = numpy.ones_like(centroids) * numpy.nan
             errors = numpy.ones_like(centroids) * numpy.nan
@@ -384,7 +387,7 @@ class Profile1D:
         models = self(x_os, collapse=False)
 
         indices = numpy.asarray([numpy.where(model >= half_max[i])[0][[0,-1]] if numpy.isfinite(model).all() else [0, 0] for i, model in enumerate(models)])
-        fwhms = numpy.diff(x_os[indices], axis=1)
+        fwhms = numpy.atleast_1d(numpy.diff(x_os[indices], axis=1).squeeze())
         errors = numpy.ones_like(fwhms) / self._oversampling_factor
         masks = (fwhms == 0) | (~numpy.isfinite(fwhms))
 
@@ -690,17 +693,17 @@ class MexHatGaussians(Profile1D):
         kernel = fiber_profile(centroids=self._fiber_radius, radii=self._fiber_radius, x=x_kernel)
         psfs = gaussians((counts, centroids, sigmas), x_os, alpha=2.0, collapse=False)
 
-        profiles = fftconvolve(psfs, kernel, mode="same", axes=1)
-        profiles /= integrate.trapezoid(profiles, x_os, axis=1)[:, None]
-        profiles *= counts[:, None]
+        models_os = fftconvolve(psfs, kernel, mode="same", axes=1)
+        models_os /= integrate.trapezoid(models_os, x_os, axis=1)[:, None]
+        models_os *= counts[:, None]
 
         # pixelate models
-        models = self._pixelate(x_os, profiles)
+        models = self._pixelate(x_os, models_os)
 
         if return_all:
             if collapse:
-                return bn.nansum(models, 0), bn.nansum(profiles, 0), x_os
-            return models, profiles, x_os
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
         if collapse:
             return bn.nansum(models, 0)
         return models
@@ -714,25 +717,31 @@ class TopHatGaussians(Profile1D):
         "sigmas"
     )
 
-    def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50, fiber_width=1.2):
+    def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50, fiber_radius=1.2):
         super().__init__(pars, fixed, bounds, ignore_nans=ignore_nans, oversampling_factor=oversampling_factor)
 
-        self._fiber_width = fiber_width
+        self._fiber_radius = fiber_radius
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         counts, centroids, sigmas = self.unpack_params()
 
         x_os = self._oversample_x(x)
 
-        width = int(self._fiber_width * self._oversampling_factor)
+        width = int(2 * self._fiber_radius * self._oversampling_factor)
         gaussians_ = gaussians((counts, centroids, sigmas), x_os, collapse=False)
         tophats = numpy.ones((counts.size, width)) / width
-        gaussians_tophats = fftconvolve(gaussians_, tophats, mode="same", axes=1)
+        models_os = fftconvolve(gaussians_, tophats, mode="same", axes=1)
 
-        model = self._pixelate(x_os, gaussians_tophats)
-        model = bn.nansum(gaussians_tophats, axis=0)
+        # pixelate models
+        models = self._pixelate(x_os, models_os)
 
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
 
 class NormalGaussians(Profile1D):
@@ -748,15 +757,20 @@ class NormalGaussians(Profile1D):
 
         self._alpha = alpha
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         pars = self.unpack_params()
 
         x_os = self._oversample_x(x)
-        models = gaussians(pars, x_os, alpha=self._alpha, collapse=False)
-        models = self._pixelate(x_os, models)
+        models_os = gaussians(pars, x_os, alpha=self._alpha, collapse=False)
+        models = self._pixelate(x_os, models_os)
 
-        model = bn.nansum(models, axis=0)
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
 
 class SkewedGaussians(Profile1D):
@@ -771,7 +785,7 @@ class SkewedGaussians(Profile1D):
     def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50):
         super().__init__(pars, fixed, bounds, ignore_nans=ignore_nans, oversampling_factor=oversampling_factor)
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         counts, centroids, sigmas, alphas = self.unpack_params()
         # convert to PDF parameters
         deltas = self._deltas(alphas)
@@ -784,11 +798,16 @@ class SkewedGaussians(Profile1D):
         # calculate normalization
         norms = numpy.trapz(shape, x_os, axis=1)
 
-        models = counts[:, numpy.newaxis] * shape / norms[:, numpy.newaxis]
-        models = self._pixelate(x_os, models)
+        models_os = counts[:, numpy.newaxis] * shape / norms[:, numpy.newaxis]
+        models = self._pixelate(x_os, models_os)
 
-        model = bn.nansum(models, axis=0)
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
     def _deltas(self, alphas):
         return alphas / numpy.sqrt(1 + alphas**2)
@@ -831,17 +850,22 @@ class PolyGaussians(Profile1D):
     def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50):
         super().__init__(pars, fixed, bounds, ignore_nans, oversampling_factor=oversampling_factor)
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         counts, centroids, sigmas, a, b, c, d = self.unpack_params()
 
         x_os = self._oversample_x(x)
         gauss = gaussians((counts, centroids, sigmas), x_os, collapse=False)
         poly = a[:,None] + b[:,None]*x_os[None,:] + c[:,None]*x_os[None,:]**2 + d[:,None]*x_os[None,:]**3
-        models = gauss + poly
-        models = self._pixelate(x_os, models)
+        models_os = gauss + poly
+        models = self._pixelate(x_os, models_os)
 
-        model = bn.nansum(models, axis=0)
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
     def _polynomial(self, x):
         counts, centroids, sigmas, a, b, c, d = self.unpack_params()
@@ -861,18 +885,23 @@ class Moffats(Profile1D):
     def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50):
         super().__init__(pars, fixed, bounds, ignore_nans, oversampling_factor=oversampling_factor)
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         counts, centroids, sigmas, betas = self.unpack_params()
 
         x_os = self._oversample_x(x)
         moffats_ = numpy.asarray([Moffat1D(1.0, centroid, sigma, beta)(x_os) for centroid, sigma, beta in zip(centroids, sigmas, betas)])
         norms = integrate.trapezoid(moffats_, x_os, axis=1)
 
-        models = counts[:, None] * moffats_ / norms[:, None]
-        models = self._pixelate(x_os, models)
+        models_os = counts[:, None] * moffats_ / norms[:, None]
+        models = self._pixelate(x_os, models_os)
 
-        model = bn.nansum(models, axis=0)
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
 class Lorentzs(Profile1D):
 
@@ -885,16 +914,21 @@ class Lorentzs(Profile1D):
     def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50):
         super().__init__(pars, fixed, bounds, ignore_nans=ignore_nans, oversampling_factor=oversampling_factor)
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         counts, centroids, sigmas = self.unpack_params()
         fwhms = sigmas * 2.354
 
         x_os = self._oversample_x(x)
-        models = [count * Lorentz1D(2/(numpy.pi*fwhm), centroid, fwhm)(x_os) for count, centroid, fwhm in zip(counts, centroids, fwhms)]
-        models = self._pixelate(x_os, models)
+        models_os = [count * Lorentz1D(2/(numpy.pi*fwhm), centroid, fwhm)(x_os) for count, centroid, fwhm in zip(counts, centroids, fwhms)]
+        models = self._pixelate(x_os, models_os)
 
-        model = bn.nansum(models, axis=0)
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
 class Voigts(Profile1D):
 
@@ -908,17 +942,22 @@ class Voigts(Profile1D):
     def __init__(self, pars, fixed, bounds, ignore_nans=True, oversampling_factor=50):
         super().__init__(pars, fixed, bounds, ignore_nans, oversampling_factor=oversampling_factor)
 
-    def __call__(self, x):
+    def __call__(self, x, collapse=True, return_all=False):
         counts, centroids, sigmas_l, sigmas_g = self.unpack_params()
         fwhms_l = sigmas_l * 2.354
         fwhms_g = sigmas_g * 2.354
 
         x_os = self._oversample_x(x)
-        models = [count * Voigt1D(centroid, 2/(numpy.pi*fwhm_l), fwhm_l, fwhm_g, method="Scipy")(x) for count, centroid, fwhm_l, fwhm_g in zip(counts, centroids, fwhms_l, fwhms_g)]
-        models = self._pixelate(x_os, models)
+        models_os = [count * Voigt1D(centroid, 2/(numpy.pi*fwhm_l), fwhm_l, fwhm_g, method="Scipy")(x) for count, centroid, fwhm_l, fwhm_g in zip(counts, centroids, fwhms_l, fwhms_g)]
+        models = self._pixelate(x_os, models_os)
 
-        model = bn.nansum(models, axis=0)
-        return model
+        if return_all:
+            if collapse:
+                return bn.nansum(models, 0), bn.nansum(models_os, 0), x_os
+            return models, models_os, x_os
+        if collapse:
+            return bn.nansum(models, 0)
+        return models
 
 
 PROFILES = {

--- a/python/lvmdrp/core/fit_profile.py
+++ b/python/lvmdrp/core/fit_profile.py
@@ -1614,9 +1614,24 @@ class Gaussian(fit_profile1D):
 
 class Gaussian_const(fit_profile1D):
     def _profile(self, x):
-        x_os = oversample(x, oversampling_factor=100)
-        model = numpy.exp(-0.5 * ((x_os - self._par[1]) / self._par[2]) ** 2) / (fact * self._par[2])
-        model = pixelate(x_os, models=self._par[0] * model[None, :] + self._par[3], oversampling_factor=100)[0]
+
+        counts = numpy.atleast_1d(self._par[0])
+        centroids = numpy.atleast_1d(self._par[1])
+        sigmas = numpy.atleast_1d(self._par[2])
+
+        x_os = oversample(x, oversampling_factor=self._oversampling_factor)
+        dx_os = x_os[1] - x_os[0]
+
+        x_kernel = numpy.arange(0, 2*self._fiber_radius + dx_os, dx_os)
+        kernel = fiber_profile(centroids=self._fiber_radius, radii=self._fiber_radius, x=x_kernel)
+        psfs = gaussians((counts, centroids, sigmas), x_os, alpha=2.0, collapse=False)
+
+        model_os = fftconvolve(psfs, kernel, mode="same", axes=1)
+        model_os /= integrate.trapezoid(model_os, x_os, axis=1)[:, None]
+        model_os *= counts
+        model_os += self._par[3]
+
+        model = pixelate(x_os, models=model_os, oversampling_factor=self._oversampling_factor)[0]
         return model
 
     def _guess_par(self, x, y):
@@ -1631,8 +1646,11 @@ class Gaussian_const(fit_profile1D):
         self._par[3] = ymin
         self._par[0] *= dx
 
-    def __init__(self, par):
+    def __init__(self, par, oversampling_factor=100, fiber_radius=0.01):
         fit_profile1D.__init__(self, par, self._profile, self._guess_par)
+
+        self._oversampling_factor = oversampling_factor
+        self._fiber_radius = fiber_radius if fiber_radius >= (1 / oversampling_factor) else (1 / oversampling_factor)
 
 
 class Gaussian_poly(fit_profile1D):

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3362,7 +3362,11 @@ class RSS(FiberRows):
             return flux_slit.squeeze(), rss._slitmap["xpmm"].data, rss._slitmap["ypmm"].data
         return flux_slit.squeeze()
 
-    def fit_ifu_gradient(self, cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec", coadd_method="average", axs=None):
+    def fit_ifu_gradient(self,
+                         cwave, dwave=8,
+                         guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
+                         coadd_method="average", norm_method=lambda x: biweight_location(x, ignore_nan=True),
+                         axs=None):
 
         if coadd_method == "average":
             z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=bn.nanmean, return_xy=True, telescope="Sci")
@@ -3373,7 +3377,7 @@ class RSS(FiberRows):
         else:
             raise ValueError(f"Invalid value for `coadd_method`: {coadd_method}. Expected either 'average', 'integrate' or 'fit'")
 
-        mu = biweight_location(z, ignore_nan=True)
+        mu = norm_method(z)
         z_ = z / mu
 
         # define guess and boundary values
@@ -3444,7 +3448,8 @@ class RSS(FiberRows):
     def measure_skyline_flatfield(self, mflat,
                                   sky_cwave, cont_cwave, dwave=8, quantiles=(5, 97),
                                   guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
-                                  coadd_method="fit", axs=None, labels=False):
+                                  coadd_method="fit", norm_method=lambda x: biweight_location(x, ignore_nan=True),
+                                  axs=None, labels=False):
         expnum = self._header["EXPOSURE"]
         imagetyp = self._header["IMAGETYP"]
 
@@ -3472,7 +3477,8 @@ class RSS(FiberRows):
 
         log.info(f"  fitting gradient and factors around sky line @ {sky_cwave:.2f} Angstroms for '{imagetyp}' exposure {expnum = }")
         x, y, z, coeffs, factor = fscience.fit_ifu_gradient(cwave=sky_cwave, dwave=dwave, groupby=groupby,
-                                                            guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs, coadd_method=coadd_method)
+                                                            guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs,
+                                                            coadd_method=coadd_method, norm_method=norm_method)
         gradient_model = IFUGradient.ifu_gradient(coeffs, x=x, y=y, normalize=True)
         log.info(f"  factors          = {numpy.round(factor, 4)}")
         log.info(f"  gradient across  = {bn.nanmax(gradient_model)/bn.nanmin(gradient_model):.4f}")

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3340,7 +3340,7 @@ class RSS(FiberRows):
 
         return wave_offsets, wave_offsets_mod
 
-    def fit_lines_slit(rss, cwaves, dwave=8, return_xy=False, select_fibers=None, axs=None):
+    def fit_lines_slit(rss, cwaves, dwave=8, fiber_radius=0.01, oversampling_factor=100, return_xy=False, select_fibers=None, axs=None):
 
         cwaves_ = numpy.atleast_1d(cwaves)
 
@@ -3363,7 +3363,10 @@ class RSS(FiberRows):
                 continue
 
             try:
-                flux, _, _, _ = spec.fit_lines(cwaves_, dwave=dwave, fiber_radius=1.0, axs=axs[iax] if axs is not None else axs)
+                flux, _, _, _ = spec.fit_lines(cwaves_, dwave=dwave,
+                                               fiber_radius=fiber_radius,
+                                               oversampling_factor=oversampling_factor,
+                                               axs=axs[iax] if axs is not None else axs)
             except ValueError as e:
                 warnings.warn(f"while fitting fiber {ifiber}: {e}")
                 continue
@@ -3376,6 +3379,8 @@ class RSS(FiberRows):
 
     def fit_ifu_gradient(self,
                          cwave, dwave=8,
+                         fiber_radius=0.01,
+                         oversampling_factor=100,
                          guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
                          coadd_method="average", norm_method=lambda x: biweight_location(x, ignore_nan=True),
                          axs=None):
@@ -3383,9 +3388,13 @@ class RSS(FiberRows):
         if coadd_method == "average":
             z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=bn.nanmean, return_xy=True, telescope="Sci")
         elif coadd_method == "integrate":
-            z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave, comb_stat=lambda a, axis: numpy.trapz(numpy.nan_to_num(a, nan=0), self._wave, axis=axis), return_xy=True, telescope="Sci")
+            z, x, y = self.coadd_flux(cwave=cwave, dwave=dwave,
+                                      comb_stat=lambda a, axis: numpy.trapz(numpy.nan_to_num(a, nan=0), self._wave, axis=axis),
+                                      return_xy=True, telescope="Sci")
         elif coadd_method == "fit":
-            z, x, y = self.fit_lines_slit(cwaves=cwave, return_xy=True, select_fibers="Sci")
+            z, x, y = self.fit_lines_slit(cwaves=cwave, dwave=dwave,
+                                          fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                                          return_xy=True, select_fibers="Sci")
         else:
             raise ValueError(f"Invalid value for `coadd_method`: {coadd_method}. Expected either 'average', 'integrate' or 'fit'")
 
@@ -3458,8 +3467,8 @@ class RSS(FiberRows):
         return rejects
 
     def measure_skyline_flatfield(self, mflat,
-                                  sky_cwave, cont_cwave, dwave=8, quantiles=(5, 97),
-                                  guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
+                                  sky_cwave, cont_cwave, dwave=8, fiber_radius=0.01, oversampling_factor=100,
+                                  quantiles=(5, 97), guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
                                   coadd_method="fit", norm_method=lambda x: biweight_location(x, ignore_nan=True),
                                   axs=None, labels=False):
         expnum = self._header["EXPOSURE"]
@@ -3488,8 +3497,9 @@ class RSS(FiberRows):
         fscience._wave = wave_trace.eval_coeffs()
 
         log.info(f"  fitting gradient and factors around sky line @ {sky_cwave:.2f} Angstroms for '{imagetyp}' exposure {expnum = }")
-        x, y, z, coeffs, factor = fscience.fit_ifu_gradient(cwave=sky_cwave, dwave=dwave, groupby=groupby,
-                                                            guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs,
+        x, y, z, coeffs, factor = fscience.fit_ifu_gradient(cwave=sky_cwave, dwave=dwave,
+                                                            fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                                                            groupby=groupby, guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs,
                                                             coadd_method=coadd_method, norm_method=norm_method)
         gradient_model = IFUGradient.ifu_gradient(coeffs, x=x, y=y, normalize=True)
         log.info(f"  factors          = {numpy.round(factor, 4)}")

--- a/python/lvmdrp/core/rss.py
+++ b/python/lvmdrp/core/rss.py
@@ -3363,7 +3363,7 @@ class RSS(FiberRows):
                 continue
 
             try:
-                flux, _, _, _ = spec.fit_lines(cwaves_, dwave=dwave, axs=axs[iax] if axs is not None else axs)
+                flux, _, _, _ = spec.fit_lines(cwaves_, dwave=dwave, fiber_radius=1.0, axs=axs[iax] if axs is not None else axs)
             except ValueError as e:
                 warnings.warn(f"while fitting fiber {ifiber}: {e}")
                 continue

--- a/python/lvmdrp/core/sky.py
+++ b/python/lvmdrp/core/sky.py
@@ -255,16 +255,19 @@ def sky_pars_header(header):
 
     """
 
+    if len(header) == 0:
+        return {}
+
     # extract useful header information,
-    sci_ra = header.get("SCIRA")
-    sci_dec = header.get("SCIDEC")
-    sci_alt = header.get("SCIALT")
-    skye_ra = header.get("SKYERA")
-    skye_dec = header.get("SKYEDEC")
-    skye_alt = header.get("SKYEALT")
-    skyw_ra = header.get("SKYWRA")
-    skyw_dec = header.get("SKYWDEC")
-    skyw_alt = header.get("SKYWALT")
+    sci_ra = header.get("SCIRA", np.nan)
+    sci_dec = header.get("SCIDEC", np.nan)
+    sci_alt = header.get("SCIALT", np.nan)
+    skye_ra = header.get("SKYERA", np.nan)
+    skye_dec = header.get("SKYEDEC", np.nan)
+    skye_alt = header.get("SKYEALT", np.nan)
+    skyw_ra = header.get("SKYWRA", np.nan)
+    skyw_dec = header.get("SKYWDEC", np.nan)
+    skyw_alt = header.get("SKYWALT", np.nan)
     obstime = header["OBSTIME"]
 
 

--- a/python/lvmdrp/core/spectrum1d.py
+++ b/python/lvmdrp/core/spectrum1d.py
@@ -3745,6 +3745,8 @@ class Spectrum1D(Header):
         cent_range=[-2.0, 2.0],
         fwhm_range=[0, 7],
         bg_range=[0, numpy.inf],
+        fiber_radius=0.01,
+        oversampling_factor=100,
         badpix_threshold=4,
         ftol=1e-8,
         xtol=1e-8,
@@ -3786,7 +3788,7 @@ class Spectrum1D(Header):
                 guess = [flux_guess, centre, fwhm_guess / 2.354, bg_guess]
                 bound_lower = [flux_range[0], centre+cent_range[0], fwhm_range[0]/2.354, bg_range[0]]
                 bound_upper = [flux_range[1], centre+cent_range[1], fwhm_range[1]/2.354, bg_range[1]]
-                gauss = fit_profile.Gaussian_const(guess)
+                gauss = fit_profile.Gaussian_const(guess, oversampling_factor=oversampling_factor, fiber_radius=fiber_radius)
             else:
                 guess = [flux_guess, centre, fwhm_guess / 2.354]
                 gauss = fit_profile.Gaussian(guess)
@@ -3813,7 +3815,7 @@ class Spectrum1D(Header):
                 select_2 = (self._wave>=cent[i]-3.5*fwhm[i]/2.354) & (self._wave<=cent[i]+3.5*fwhm[i]/2.354)
                 x = self._wave[select_2]
                 axs[i].plot(self._wave, (select)*numpy.nan+bn.nanmin(data), "ok")
-                axs_ = gauss.plot(self._wave[select], self._data[select], mask=self._mask[select], axs={"mod": axs[i]})
+                axs_ = gauss.plot(self._wave[select], self._data[select], self._error[select], mask=self._mask[select], axs={"mod": axs[i]})
                 axs[i] = axs_["mod"]
                 axs[i].axhline(bg[i], ls="--", color="tab:blue", lw=1)
                 if len(x) != 0:
@@ -4111,7 +4113,7 @@ class Spectrum1D(Header):
 
         return Spectrum1D(wave=wave, data=fluxes, error=errors, lsf=fwhms, mask=masks, sky=skies, sky_error=sky_errors)
 
-    def fit_lines(self, cwaves, dwave=8, axs=None):
+    def fit_lines(self, cwaves, dwave=8, fiber_radius=0.01, oversampling_factor=100, axs=None):
 
         cwaves_ = numpy.atleast_1d(cwaves)
 
@@ -4128,5 +4130,7 @@ class Spectrum1D(Header):
                                                     [-2.5, 2.5],
                                                     [max(fwhm_guess - 1.5, 0), fwhm_guess + 1.5],
                                                     [0.0, numpy.inf],
+                                                    fiber_radius=fiber_radius,
+                                                    oversampling_factor=oversampling_factor,
                                                     axs=axs)
         return flux, sky_wave, fwhm, bg

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1624,6 +1624,7 @@ def correctTraceMask_drp(trace_in, trace_out, logfile, ref_file, poly_smooth="")
 def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
                     sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT,
                     cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
+                    dwave: float = 20.0,
                     groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0),
                     coadd_method="fit", norm_method=lambda x: biweight_location(x, ignore_nan=True),
                     display_plots: bool = False) -> RSS:
@@ -1657,7 +1658,6 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
     channel = rss._header["CCD"][0]
     sky_cwave = sky_cwaves[channel]
     cont_cwave = cont_cwaves[channel]
-    dwave = 20.0
 
     # load fiberflat
     log.info(f"reading fiberflat from {os.path.basename(in_flat)}")

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -17,7 +17,7 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.time import Time
 from astropy.wcs import WCS
-from astropy.stats import biweight_scale
+from astropy.stats import biweight_location, biweight_scale
 from numpy import polynomial
 from scipy import interpolate, ndimage
 
@@ -1624,7 +1624,9 @@ def correctTraceMask_drp(trace_in, trace_out, logfile, ref_file, poly_smooth="")
 def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
                     sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT,
                     cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
-                    groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0), display_plots: bool = False) -> RSS:
+                    groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0),
+                    coadd_method="fit", norm_method=lambda x: biweight_location(x, ignore_nan=True),
+                    display_plots: bool = False) -> RSS:
     """applies fiberflat correction to target RSS file
 
     This function applies a fiberflat correction to a target RSS file. The
@@ -1684,6 +1686,7 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
     x, y, skyline_slit, coeffs, factor, _ = rss.measure_skyline_flatfield(
             mflat=mflat, sky_cwave=sky_cwave, cont_cwave=cont_cwave, dwave=dwave,
             quantiles=quantiles, guess_coeffs=[1,0,0,0], fixed_coeffs=[0,1,2,3], groupby=groupby,
+            coadd_method=coadd_method, norm_method=norm_method,
             axs=axs, labels=True)
 
     log.info("applying flatfield correction")

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -10,6 +10,7 @@ import matplotlib
 import matplotlib.gridspec as gridspec
 import numpy
 import yaml
+import warnings
 import bottleneck as bn
 from tqdm import tqdm
 from astropy import units as u
@@ -22,18 +23,16 @@ from numpy import polynomial
 from scipy import interpolate, ndimage
 
 from lvmdrp.utils.decorators import skip_on_missing_input_path, skip_if_drpqual_flags
-from lvmdrp.core.constants import CONFIG_PATH, ARC_LAMPS, REF_SKYLINES, SKYLINES_FIBERFLAT, CONTINUUM_FIBERFLAT
+from lvmdrp.core.constants import CONFIG_PATH, ARC_LAMPS, REF_SKYLINES, SKYLINES_FIBERFLAT
 from lvmdrp.core.cube import Cube
 from lvmdrp.core.tracemask import TraceMask
 from lvmdrp.core.image import loadImage
 from lvmdrp.core.passband import PassBand
-from lvmdrp.core import fit_profile as fp
 from lvmdrp.core.plot import (plt, create_subplots, save_fig,
                               plot_error,
                               plot_wavesol_coeffs, plot_wavesol_residuals,
                               plot_wavesol_spec, plot_wavesol_wave,
                               plot_wavesol_lsf,
-                              plot_gradient_fit,
                               slit)
 from lvmdrp.core.rss import RSS, _read_pixwav_map, loadRSS, lvmFrame, lvmFFrame, lvmCFrame
 from lvmdrp.core.spectrum1d import Spectrum1D, _spec_from_lines, _cross_match_float
@@ -1623,16 +1622,11 @@ def correctTraceMask_drp(trace_in, trace_out, logfile, ref_file, poly_smooth="")
 
 
 def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
-                    fit_factors: bool = True,
-                    fit_gradient: bool = False,
-                    assume_factors: numpy.ndarray | None = None,
-                    assume_coeffs: numpy.ndarray | None = None,
                     sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT,
-                    cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
-                    dwave: float = 20.0,
-                    fiber_radius: float = 0.01, oversampling_factor: int = 100,
-                    groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0),
-                    coadd_method="fit", norm_method=lambda x: biweight_location(x, ignore_nan=True),
+                    dwave: float = 10.0,
+                    fiber_radius: float = 1.0, oversampling_factor: int = 100,
+                    groupby: str = "spec", coadd_method="fit",
+                    norm_method=lambda x: biweight_location(x, ignore_nan=True),
                     display_plots: bool = False) -> RSS:
     """applies fiberflat correction to target RSS file
 
@@ -1663,10 +1657,9 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
     rss = RSS.from_file(in_rss)
     channel = rss._header["CCD"][0]
     sky_cwave = sky_cwaves[channel]
-    cont_cwave = cont_cwaves[channel]
 
     # load fiberflat
-    log.info(f"reading fiberflat from {os.path.basename(in_flat)}")
+    log.info(f"reading fiberflat from {in_flat}")
     mflat = RSS.from_file(in_flat)
     if mflat._wave is None:
         mflat.set_wave_trace(rss._wave_trace)
@@ -1681,40 +1674,22 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
     if not numpy.isclose(rss._wave, mflat._wave).all():
         log.warning("target data and fiberflat have different wavelength grids")
         rss.add_header_comment("target data and fiberflat have different wavelength grids")
+    if not mflat._header.get(f"{channel} FIBERFLAT SKYCORR", False):
+        warnings.warn("Using a master fiber flat without spectrograph-to-spectrograph correction")
 
     # apply flatfield and measure sky lines
+    rss /= mflat
+    skyline_slit = rss.fit_lines_slit(cwaves=sky_cwave, dwave=dwave, fiber_radius=1.0, select_fibers="Sci")
+
     fig = plt.figure(figsize=(14,3*2))
     fig.suptitle(f"Fiber flatfield correction for {channel = } around sky line @ {sky_cwave:.2f} Angstroms", fontsize="xx-large")
     gs_gra = gridspec.GridSpec(2, 5, hspace=0.01, wspace=0.01, left=0.07, right=0.99, figure=fig)
     gs_cor = gridspec.GridSpec(2, 5, hspace=0.5, wspace=0.01, left=0.07, right=0.99, figure=fig)
     axs = [fig.add_subplot(gs_gra[0, j]) for j in range(5)]
-
-    fiber_groups = mflat._get_fiber_groups(by="spec")
-    factor = assume_factors if assume_factors is not None else numpy.ones(len(set(fiber_groups)), dtype="float")
-    coeffs = assume_coeffs if assume_coeffs is not None else numpy.array([1,0,0,0], dtype="float")
-    fixed_coeffs = [0,1,2,3] if not fit_gradient else [3]
-    log.info(f"measuring sky line {sky_cwave:.2f}+/-{dwave:.2f} Angstroms in {rss._fibers} fibers")
-    if fit_factors:
-        x, y, skyline_slit, coeffs, factor, _ = rss.measure_skyline_flatfield(
-                mflat=mflat, sky_cwave=sky_cwave, cont_cwave=cont_cwave, dwave=dwave,
-                fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
-                quantiles=quantiles, guess_coeffs=coeffs, fixed_coeffs=fixed_coeffs, groupby=groupby,
-                coadd_method=coadd_method, norm_method=norm_method,
-                axs=None, labels=True)
-
-        log.info("applying flatfield correction")
-    else:
-        skyline_slit, x, y = (rss / mflat).fit_lines_slit(
-            cwaves=sky_cwave, dwave=dwave,
-            fiber_radius=fiber_radius, oversampling_factor=oversampling_factor, select_fibers="Sci", return_xy=True)
-
-    flatfield_corr, g, f = fp.IFUGradient.ifu_joint_model(coeffs, factor, x, y, fiber_groups, normalize=True, return_components=True)
-    plot_gradient_fit(rss._slitmap, skyline_slit, g, f, telescope="Sci", axs=axs)
-
-    mflat *= flatfield_corr[:, None]
-    rss /= mflat
-    skyline_slit /= flatfield_corr
-
+    rss.fit_ifu_gradient(cwave=sky_cwave, dwave=dwave, groupby=groupby,
+                         fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                         guess_coeffs=[1,0,0,0], fixed_coeffs=[3], coadd_method=coadd_method,
+                         norm_method=norm_method, axs=axs)
     ax_cor = fig.add_subplot(gs_cor[-1, :])
     ax_cor.set_title(f"Flatfielded skyline @ {sky_cwave:.2f}+/-{dwave:.2f} Angstroms", loc="left")
     ax_cor.set_xlabel("Fiber ID", fontsize="large")
@@ -1740,15 +1715,6 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
         superflat=mflat._data
     )
     lvmframe.set_header(orig_header=rss._header.copy(), flatname=os.path.basename(in_flat))
-    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
-    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
-    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT COADD", coadd_method, "coadding method")
-    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
-    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
-    for i, f in enumerate(factor):
-        lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", numpy.round(f, 5), f"fiberflat factor {groupby}{i+1}")
-    for i, c in enumerate(coeffs):
-        lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", numpy.round(c, 5), f"IFU gradient coeff #{i+1}")
     lvmframe.writeFitsData(out_frame)
 
     return rss, lvmframe

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -33,6 +33,7 @@ from lvmdrp.core.plot import (plt, create_subplots, save_fig,
                               plot_wavesol_coeffs, plot_wavesol_residuals,
                               plot_wavesol_spec, plot_wavesol_wave,
                               plot_wavesol_lsf,
+                              plot_gradient_fit,
                               slit)
 from lvmdrp.core.rss import RSS, _read_pixwav_map, loadRSS, lvmFrame, lvmFFrame, lvmCFrame
 from lvmdrp.core.spectrum1d import Spectrum1D, _spec_from_lines, _cross_match_float
@@ -1622,9 +1623,14 @@ def correctTraceMask_drp(trace_in, trace_out, logfile, ref_file, poly_smooth="")
 
 
 def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
+                    fit_factors: bool = True,
+                    fit_gradient: bool = False,
+                    assume_factors: numpy.ndarray | None = None,
+                    assume_coeffs: numpy.ndarray | None = None,
                     sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT,
                     cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
                     dwave: float = 20.0,
+                    fiber_radius: float = 0.01, oversampling_factor: int = 100,
                     groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0),
                     coadd_method="fit", norm_method=lambda x: biweight_location(x, ignore_nan=True),
                     display_plots: bool = False) -> RSS:
@@ -1682,22 +1688,32 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
     gs_gra = gridspec.GridSpec(2, 5, hspace=0.01, wspace=0.01, left=0.07, right=0.99, figure=fig)
     gs_cor = gridspec.GridSpec(2, 5, hspace=0.5, wspace=0.01, left=0.07, right=0.99, figure=fig)
     axs = [fig.add_subplot(gs_gra[0, j]) for j in range(5)]
-    log.info(f"measuring sky line {sky_cwave:.2f}+/-{dwave:.2f} Angstroms in {rss._fibers} fibers")
-    x, y, skyline_slit, coeffs, factor, _ = rss.measure_skyline_flatfield(
-            mflat=mflat, sky_cwave=sky_cwave, cont_cwave=cont_cwave, dwave=dwave,
-            quantiles=quantiles, guess_coeffs=[1,0,0,0], fixed_coeffs=[0,1,2,3], groupby=groupby,
-            coadd_method=coadd_method, norm_method=norm_method,
-            axs=axs, labels=True)
 
-    log.info("applying flatfield correction")
     fiber_groups = mflat._get_fiber_groups(by="spec")
-    flatfield_corr = fp.IFUGradient.ifu_factors(factor, fiber_groups)
+    factor = assume_factors if assume_factors is not None else numpy.ones(len(set(fiber_groups)), dtype="float")
+    coeffs = assume_coeffs if assume_coeffs is not None else numpy.array([1,0,0,0], dtype="float")
+    fixed_coeffs = [0,1,2,3] if not fit_gradient else [3]
+    log.info(f"measuring sky line {sky_cwave:.2f}+/-{dwave:.2f} Angstroms in {rss._fibers} fibers")
+    if fit_factors:
+        x, y, skyline_slit, coeffs, factor, _ = rss.measure_skyline_flatfield(
+                mflat=mflat, sky_cwave=sky_cwave, cont_cwave=cont_cwave, dwave=dwave,
+                fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                quantiles=quantiles, guess_coeffs=coeffs, fixed_coeffs=fixed_coeffs, groupby=groupby,
+                coadd_method=coadd_method, norm_method=norm_method,
+                axs=None, labels=True)
+
+        log.info("applying flatfield correction")
+    else:
+        skyline_slit, x, y = (rss / mflat).fit_lines_slit(
+            cwaves=sky_cwave, dwave=dwave,
+            fiber_radius=fiber_radius, oversampling_factor=oversampling_factor, select_fibers="Sci", return_xy=True)
+
+    flatfield_corr, g, f = fp.IFUGradient.ifu_joint_model(coeffs, factor, x, y, fiber_groups, normalize=True, return_components=True)
+    plot_gradient_fit(rss._slitmap, skyline_slit, g, f, telescope="Sci", axs=axs)
+
     mflat *= flatfield_corr[:, None]
     rss /= mflat
     skyline_slit /= flatfield_corr
-
-    # update pixel mask
-    rss._mask = numpy.isnan(rss._data)|numpy.isnan(rss._error)
 
     ax_cor = fig.add_subplot(gs_cor[-1, :])
     ax_cor.set_title(f"Flatfielded skyline @ {sky_cwave:.2f}+/-{dwave:.2f} Angstroms", loc="left")
@@ -1706,6 +1722,9 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
     ax_cor.set_ylim(0.92, 1.08)
     slit(x=rss._slitmap["fiberid"].data, y=skyline_slit, data=rss._data, ax=ax_cor)
     save_fig(fig, out_frame, to_display=display_plots, figure_path="qa", label="fiberflat_correction")
+
+    # update pixel mask
+    rss._mask = numpy.isnan(rss._data)|numpy.isnan(rss._error)
 
     # create lvmFrame
     log.info(f"writing lvmFrame to {os.path.basename(out_frame)}")

--- a/python/lvmdrp/functions/rssMethod.py
+++ b/python/lvmdrp/functions/rssMethod.py
@@ -1739,10 +1739,16 @@ def apply_fiberflat(in_rss: str, out_frame: str, in_flat: str,
         slitmap=rss._slitmap,
         superflat=mflat._data
     )
-    rss._header[f"HIERARCH {channel.upper()}1 FIBERFLAT CORR"] =  (numpy.round(factor[0], 5), "fiberflat corr. spec. 1")
-    rss._header[f"HIERARCH {channel.upper()}2 FIBERFLAT CORR"] =  (numpy.round(factor[1], 5), "fiberflat corr. spec. 2")
-    rss._header[f"HIERARCH {channel.upper()}3 FIBERFLAT CORR"] =  (numpy.round(factor[2], 5), "fiberflat corr. spec. 3")
-    lvmframe.set_header(orig_header=rss._header, flatname=os.path.basename(in_flat))
+    lvmframe.set_header(orig_header=rss._header.copy(), flatname=os.path.basename(in_flat))
+    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
+    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
+    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT COADD", coadd_method, "coadding method")
+    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
+    lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
+    for i, f in enumerate(factor):
+        lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", numpy.round(f, 5), f"fiberflat factor {groupby}{i+1}")
+    for i, c in enumerate(coeffs):
+        lvmframe.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", numpy.round(c, 5), f"IFU gradient coeff #{i+1}")
     lvmframe.writeFitsData(out_frame)
 
     return rss, lvmframe

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -130,10 +130,15 @@ def _read_ffactors(drpver, channel):
 def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=20.0,
                       fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
                       groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
-                      fit_gradient=False,
-                      label=None, write_table=False):
+                      fit_gradient=False, label=None, write_table=False, table_dir=None, display_plots=False):
     # define label if not given
-    label = label or norm_stat.__name__
+    label = label or "".join(filter(str.isalnum, norm_stat.__name__))
+
+    # define paths
+    name = f"ffactors-{drpver}-{mjd}-{channel}-{label}"
+    table_dir = table_dir or "./"
+    os.makedirs(table_dir, exist_ok=True)
+    table_path = os.path.join(table_dir, f"{name}.csv")
 
     # grab all relevant DRP products: before/ after fiber flat fielding
     channel_ = "?" if channel == "all" else channel
@@ -192,6 +197,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         ax_cor.set_ylabel("Normalized counts", fontsize="large")
         ax_cor.set_ylim(0.92, 1.08)
         slit(x=rss._slitmap["fiberid"].data, y=skyline_slit, data=rss._data, ax=ax_cor)
+        save_fig(fig, product_path=f"{table_path.replace('.csv', '')}-{expnum:>08d}.fits", figure_path="qa", to_display=display_plots)
 
         rss._header[f"HIERARCH {channel.upper()} FIBERFLAT GRAD"] = (np.round(bn.nanmax(gradient_model)/bn.nanmin(gradient_model), 5), "fiberflat field gradient")
         rss._header[f"HIERARCH {channel.upper()}1 FIBERFLAT CORR"] =  (np.round(factor[0], 5), "fiberflat corr. spec. 1")
@@ -204,7 +210,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
     metadata = pd.DataFrame(metadata)
     metadata.sort_values("exposure", inplace=True)
     if write_table:
-        metadata.to_csv(f"ffactors-{drpver}-{channel}-{label}.csv")
+        metadata.to_csv(table_path)
 
     return metadata
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -39,6 +39,7 @@ from datetime import datetime
 from shutil import copy2, copytree
 from astropy.io import fits
 from astropy.table import Table
+from astropy.stats import biweight_location
 from typing import Union, Tuple, List, Dict
 from collections.abc import Callable
 from matplotlib.gridspec import GridSpec
@@ -126,7 +127,7 @@ def _read_ffactors(drpver, channel):
     return pd.DataFrame(metadata)
 
 
-def _measure_ffactors(mjd, drpver, channel, norm_stat=bn.nanmean, label=None, write_table=False):
+def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, norm_stat=lambda x: biweight_location(x, ignore_nan=True), label=None, write_table=False):
     label = label or norm_stat.__name__
 
     # define general parameters
@@ -136,7 +137,10 @@ def _measure_ffactors(mjd, drpver, channel, norm_stat=bn.nanmean, label=None, wr
 
     # grab all relevant DRP products: before/ after fiber flat fielding
     channel_ = "?" if channel == "all" else channel
-    wframe_paths = sorted(path.expand("lvm_anc", drpver=drpver, tileid="*", mjd=mjd, expnum="????????", imagetype="object", kind="w", camera=channel_))
+    wframe_paths = sorted(
+        path.expand("lvm_anc", drpver=drpver, tileid="*", mjd=mjd, expnum="????????", imagetype="object", kind="w", camera=channel_),
+        key=lambda s: int(os.path.basename(s).split(".")[0].split("-")[-1]))
+
     # grab master fiber flat fields
     mflat_paths = get_calib_paths(mjd=mjd, flavors={"fiberflat_twilight"}, from_sandbox=True)["fiberflat_twilight"]
 
@@ -146,12 +150,13 @@ def _measure_ffactors(mjd, drpver, channel, norm_stat=bn.nanmean, label=None, wr
         rss = RSS.from_file(wframe_path)
 
         channel_current = rss._header["CCD"][0]
-        sky_cwave = SKYLINES_FIBERFLAT[channel_current]
+        expnum = rss._header["EXPOSURE"]
+        sky_cwave = sky_lines[channel_current]
         cont_cwave = CONTINUUM_FIBERFLAT[channel_current]
         mflat = RSS.from_file(mflat_paths[channel_current])
 
         fig = plt.figure(figsize=(14,3*2))
-        fig.suptitle(f"Fiber flatfield correction for {channel = } around sky line @ {sky_cwave:.2f} Angstroms", fontsize="xx-large")
+        fig.suptitle(f"Fiber flatfield correction for {expnum = } {channel = } around sky line @ {sky_cwave:.2f} Angstroms", fontsize="xx-large")
         gs_gra = GridSpec(2, 5, hspace=0.01, wspace=0.01, left=0.07, right=0.99, figure=fig)
         gs_cor = GridSpec(2, 5, hspace=0.5, wspace=0.01, left=0.07, right=0.99, figure=fig)
         axs = [fig.add_subplot(gs_gra[0, j]) for j in range(5)]
@@ -160,7 +165,7 @@ def _measure_ffactors(mjd, drpver, channel, norm_stat=bn.nanmean, label=None, wr
             sky_cwave=sky_cwave,
             cont_cwave=cont_cwave,
             dwave=dwave,
-            quantiles=quantiles, guess_coeffs=[1,0,0,0], fixed_coeffs=[0,1,2,3], groupby=groupby,
+            quantiles=quantiles, guess_coeffs=[1,0,0,0], fixed_coeffs=[1,2,3], groupby=groupby,
             axs=axs, labels=True)
 
         log.info("applying flatfield correction")

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -106,7 +106,7 @@ CALIBRATION_EPOCHS_PATH = os.path.join(os.getenv("LVMCORE_DIR"), "calibrations",
 def _extract_ffactors(header):
     channel = header["CCD"][0]
     columns = [
-        "obstime", "smjd", "tile_id", "exposure", "scira", "scidec",
+        "obstime", "smjd", "tile_id", "exposure", "scira", "scidec", f"{channel} fiberflat grad",
         f"{channel}1 fiberflat corr", f"{channel}2 fiberflat corr", f"{channel}3 fiberflat corr"]
 
     metadata_row = {k.replace(" ", "_"): header.get(k) for k in columns}
@@ -127,13 +127,13 @@ def _read_ffactors(drpver, channel):
     return pd.DataFrame(metadata)
 
 
-def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, norm_stat=lambda x: biweight_location(x, ignore_nan=True), label=None, write_table=False):
+def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=20.0,
+                      fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
+                      groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
+                      fit_gradient=False,
+                      label=None, write_table=False):
+    # define label if not given
     label = label or norm_stat.__name__
-
-    # define general parameters
-    dwave = 20.0
-    quantiles = (5.0, 97.0)
-    groupby = "spec"
 
     # grab all relevant DRP products: before/ after fiber flat fielding
     channel_ = "?" if channel == "all" else channel
@@ -165,8 +165,16 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, norm_s
             sky_cwave=sky_cwave,
             cont_cwave=cont_cwave,
             dwave=dwave,
-            quantiles=quantiles, guess_coeffs=[1,0,0,0], fixed_coeffs=[1,2,3], groupby=groupby,
-            axs=axs, labels=True)
+            fiber_radius=fiber_radius,
+            oversampling_factor=oversampling_factor,
+            coadd_method=coadd_method,
+            quantiles=quantiles,
+            guess_coeffs=[1,0,0,0],
+            fixed_coeffs=[3] if fit_gradient else [1, 2, 3],
+            groupby=groupby, axs=axs, labels=True)
+
+        log.info("evaluating gradient model")
+        gradient_model = IFUGradient.ifu_gradient(coeffs, x=x, y=y, normalize=True)
 
         log.info("applying flatfield correction")
         fiber_groups = mflat._get_fiber_groups(by="spec")
@@ -185,6 +193,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, norm_s
         ax_cor.set_ylim(0.92, 1.08)
         slit(x=rss._slitmap["fiberid"].data, y=skyline_slit, data=rss._data, ax=ax_cor)
 
+        rss._header[f"HIERARCH {channel.upper()} FIBERFLAT GRAD"] = (np.round(bn.nanmax(gradient_model)/bn.nanmin(gradient_model), 5), "fiberflat field gradient")
         rss._header[f"HIERARCH {channel.upper()}1 FIBERFLAT CORR"] =  (np.round(factor[0], 5), "fiberflat corr. spec. 1")
         rss._header[f"HIERARCH {channel.upper()}2 FIBERFLAT CORR"] =  (np.round(factor[1], 5), "fiberflat corr. spec. 2")
         rss._header[f"HIERARCH {channel.upper()}3 FIBERFLAT CORR"] =  (np.round(factor[2], 5), "fiberflat corr. spec. 3")

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -32,6 +32,7 @@ import numpy as np
 import bottleneck as bn
 import pandas as pd
 from itertools import product
+from tqdm import tqdm
 from pprint import pformat
 from copy import deepcopy as copy
 from datetime import datetime
@@ -49,7 +50,7 @@ from lvmdrp.utils import hdrfix
 from lvmdrp.utils.convert import tileid_grp
 from lvmdrp.utils.paths import get_calib_paths, group_calib_paths, get_frames_paths
 from lvmdrp.utils import pixshifts
-from lvmdrp.core.plot import save_fig
+from lvmdrp.core.plot import save_fig, slit
 from lvmdrp.core import dataproducts as dp
 from lvmdrp.core.constants import (
     LVM_NFIBERS,
@@ -71,10 +72,11 @@ from lvmdrp.core.constants import (
 from lvmdrp.core.tracemask import TraceMask
 from lvmdrp.core.image import loadImage
 from lvmdrp.core.rss import RSS, lvmFrame
-from lvmdrp.core.fit_profile import gaussians
+from lvmdrp.core.fit_profile import gaussians, IFUGradient
 
 from lvmdrp.functions import imageMethod as image_tasks
 from lvmdrp.functions import rssMethod as rss_tasks
+from lvmdrp.functions import sky_qa as sky
 from lvmdrp.main import start_logging, get_config_options, read_fibermap, reduce_2d, reduce_1d
 from lvmdrp.functions.run_twilights import lvmFlat, to_native_wave, fit_fiberflat, combine_twilight_sequence, fit_skyline_flatfield
 
@@ -98,6 +100,99 @@ FIBER_SMOOTHING_CONFIG = {
 
 
 CALIBRATION_EPOCHS_PATH = os.path.join(os.getenv("LVMCORE_DIR"), "calibrations", "calibration-epochs.yaml")
+
+
+def _extract_ffactors(header):
+    channel = header["CCD"][0]
+    columns = [
+        "obstime", "smjd", "tile_id", "exposure", "scira", "scidec",
+        f"{channel}1 fiberflat corr", f"{channel}2 fiberflat corr", f"{channel}3 fiberflat corr"]
+
+    metadata_row = {k.replace(" ", "_"): header.get(k) for k in columns}
+    metadata_sky = sky.create_overview(header)
+    metadata_row.update(metadata_sky)
+
+    return metadata_row
+
+
+def _read_ffactors(drpver, channel):
+    frame_paths: list[str] = sorted(path.expand("lvm_frame", drpver=drpver, tileid="*", mjd="*", expnum="????????", kind=f"Frame-{channel}"))
+
+    metadata = []
+    for p in tqdm(frame_paths, desc=f"extracting factors for {drpver = } | {channel = }", ascii=True, unit="exposure"):
+        hdr = fits.getheader(p)
+
+        metadata.append(_extract_ffactors(hdr))
+    return pd.DataFrame(metadata)
+
+
+def _measure_ffactors(mjd, drpver, channel, norm_stat=bn.nanmean, label=None, write_table=False):
+    label = label or norm_stat.__name__
+
+    # define general parameters
+    dwave = 20.0
+    quantiles = (5.0, 97.0)
+    groupby = "spec"
+
+    # grab all relevant DRP products: before/ after fiber flat fielding
+    channel_ = "?" if channel == "all" else channel
+    wframe_paths = sorted(path.expand("lvm_anc", drpver=drpver, tileid="*", mjd=mjd, expnum="????????", imagetype="object", kind="w", camera=channel_))
+    # grab master fiber flat fields
+    mflat_paths = get_calib_paths(mjd=mjd, flavors={"fiberflat_twilight"}, from_sandbox=True)["fiberflat_twilight"]
+
+    # measure/fit flat-field factors using given normalization statistic
+    metadata = []
+    for wframe_path in wframe_paths:
+        rss = RSS.from_file(wframe_path)
+
+        channel_current = rss._header["CCD"][0]
+        sky_cwave = SKYLINES_FIBERFLAT[channel_current]
+        cont_cwave = CONTINUUM_FIBERFLAT[channel_current]
+        mflat = RSS.from_file(mflat_paths[channel_current])
+
+        fig = plt.figure(figsize=(14,3*2))
+        fig.suptitle(f"Fiber flatfield correction for {channel = } around sky line @ {sky_cwave:.2f} Angstroms", fontsize="xx-large")
+        gs_gra = GridSpec(2, 5, hspace=0.01, wspace=0.01, left=0.07, right=0.99, figure=fig)
+        gs_cor = GridSpec(2, 5, hspace=0.5, wspace=0.01, left=0.07, right=0.99, figure=fig)
+        axs = [fig.add_subplot(gs_gra[0, j]) for j in range(5)]
+        x, y, skyline_slit, coeffs, factor, _ = rss.measure_skyline_flatfield(
+            mflat=mflat,
+            sky_cwave=sky_cwave,
+            cont_cwave=cont_cwave,
+            dwave=dwave,
+            quantiles=quantiles, guess_coeffs=[1,0,0,0], fixed_coeffs=[0,1,2,3], groupby=groupby,
+            axs=axs, labels=True)
+
+        log.info("applying flatfield correction")
+        fiber_groups = mflat._get_fiber_groups(by="spec")
+        flatfield_corr = IFUGradient.ifu_factors(factor, fiber_groups)
+        mflat *= flatfield_corr[:, None]
+        rss /= mflat
+        skyline_slit /= flatfield_corr
+
+        # update pixel mask
+        rss._mask = np.isnan(rss._data)|np.isnan(rss._error)
+
+        ax_cor = fig.add_subplot(gs_cor[-1, :])
+        ax_cor.set_title(f"Flatfielded skyline @ {sky_cwave:.2f}+/-{dwave:.2f} Angstroms", loc="left")
+        ax_cor.set_xlabel("Fiber ID", fontsize="large")
+        ax_cor.set_ylabel("Normalized counts", fontsize="large")
+        ax_cor.set_ylim(0.92, 1.08)
+        slit(x=rss._slitmap["fiberid"].data, y=skyline_slit, data=rss._data, ax=ax_cor)
+
+        rss._header[f"HIERARCH {channel.upper()}1 FIBERFLAT CORR"] =  (np.round(factor[0], 5), "fiberflat corr. spec. 1")
+        rss._header[f"HIERARCH {channel.upper()}2 FIBERFLAT CORR"] =  (np.round(factor[1], 5), "fiberflat corr. spec. 2")
+        rss._header[f"HIERARCH {channel.upper()}3 FIBERFLAT CORR"] =  (np.round(factor[2], 5), "fiberflat corr. spec. 3")
+
+        # extract flat field factors and additional information
+        metadata.append(_extract_ffactors(rss._header))
+
+    metadata = pd.DataFrame(metadata)
+    metadata.sort_values("exposure", inplace=True)
+    if write_table:
+        metadata.to_csv(f"ffactors-{drpver}-{channel}-{label}.csv")
+
+    return metadata
 
 
 def _reject_pixelshifted(frames, pixelshifts_path=PIXELSHIFTS_PATH):
@@ -921,6 +1016,9 @@ def tag_longterm_calibrations(mjd, version, flavors=None, dry_run=False):
     dry_run : bool, optional
         Logs useful information abaut the current setup without actually tagging, by default False
     """
+
+    # TODO: clean all MJD directories from the calib
+
     # handle possible acceptable flavors
     if isinstance(flavors, (list, tuple, set, np.ndarray)):
         flavors = set(flavors)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -131,7 +131,12 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
                       fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
                       groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
                       fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False,
-                      display_plots=False, dry_run=False):
+                      use_untagged_cals=False, version_cals=None, display_plots=False, dry_run=False):
+
+    if use_untagged_cals and version_cals is None:
+        log.error(f"Invalid value for `version_cals`: {version_cals}. Expected a long-term calibration version tag, .e.g, '1.2.2dev'")
+        return
+
     if mjd is None:
         log.error("no MJD given, nothing to do")
         return
@@ -157,12 +162,15 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         return
 
     log.info(f"going to estimate flat field factors for {len(wframe_paths)} frames, {mjd = }, channel = {channel_}")
-    if dry_run:
-        log.info(f"output table at {table_path}")
-        return
 
     # grab master fiber flat fields
-    mflat_paths = get_calib_paths(mjd=mjd, flavors={"fiberflat_twilight"}, from_sandbox=True)["fiberflat_twilight"]
+    mflat_paths = get_calib_paths(mjd=mjd, from_sandbox=not use_untagged_cals, version=version_cals)["fiberflat_twilight"]
+    if dry_run:
+        log.info(f"using calibrations:")
+        for channel in mflat_paths:
+            log.info(f"{channel = }: {mflat_paths[channel]}")
+        log.info(f"output table at {table_path}")
+        return
 
     # measure/fit flat-field factors using given normalization statistic
     metadata = []

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -2305,8 +2305,8 @@ def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epoc
 
     # perform 2D, 1D reductions, down to wavelength calibrated products
     for mjd in source_mjds:
-        # get calibration paths from untagged epochs
-        calibs = get_calib_paths(get_master_mjd(mjd), version=drpver, from_sandbox=False)
+        # use the calibration epoch that covers this source MJD
+        calibs = get_calib_paths(mjd=mjd, version=drpver, flavors=CALIBRATION_NEEDS["twilight"], epochs=calibration_epochs, from_sandbox=False)
 
         # reduce science/twilight exposures down to wavelength calibration step
         reduce_2d(mjds=mjd, calibrations=calibs, expnums=expnums, add_astro=use_science, sub_straylight=True, skip_done=skip_done)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -148,6 +148,9 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         path.expand("lvm_anc", drpver=drpver, tileid="*", mjd=mjd, expnum="????????", imagetype="object", kind="w", camera=channel_),
         key=lambda s: int(os.path.basename(s).split(".")[0].split("-")[-1]))
 
+    if len(wframe_paths) == 0:
+        return
+
     # grab master fiber flat fields
     mflat_paths = get_calib_paths(mjd=mjd, flavors={"fiberflat_twilight"}, from_sandbox=True)["fiberflat_twilight"]
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -41,7 +41,7 @@ from shutil import copy2, copytree
 from astropy.io import fits
 from astropy.table import Table
 from astropy.stats import biweight_location
-from typing import Union, Tuple, List, Dict
+from typing import Union, List, Dict
 from collections.abc import Callable
 from matplotlib.gridspec import GridSpec
 import matplotlib.pyplot as plt
@@ -50,7 +50,7 @@ from lvmdrp import log, path, __version__ as drpver
 from lvmdrp.utils import metadata as md
 from lvmdrp.utils import hdrfix
 from lvmdrp.utils.convert import tileid_grp
-from lvmdrp.utils.paths import get_calib_paths, group_calib_paths, get_frames_paths, get_master_mjd
+from lvmdrp.utils.paths import get_calib_paths, group_calib_paths, get_master_mjd
 from lvmdrp.utils import pixshifts
 from lvmdrp.core.plot import save_fig, slit
 from lvmdrp.core import dataproducts as dp
@@ -80,7 +80,9 @@ from lvmdrp.functions import imageMethod as image_tasks
 from lvmdrp.functions import rssMethod as rss_tasks
 from lvmdrp.core import sky
 from lvmdrp.main import start_logging, get_config_options, read_fibermap, reduce_2d, reduce_1d
-from lvmdrp.functions.run_twilights import lvmFlat, to_native_wave, fit_fiberflat, combine_twilight_sequence, fit_skyline_flatfield
+from lvmdrp.functions.run_twilights import (
+    lvmFlat, to_native_wave, fit_fiberflat, combine_twilight_sequence,
+    do_ffactor_correction, undo_ffactor_correction)
 
 
 SLITMAP = read_fibermap(as_table=True)
@@ -114,8 +116,9 @@ EPOCHS_FILE_PATH = {
 
 def _extract_ffactors(channel, header):
     columns = [
-        "obstime", "smjd", "tile_id", "exposure", "scira", "scidec", f"{channel} fiberflat grad",
-        f"{channel}1 fiberflat corr", f"{channel}2 fiberflat corr", f"{channel}3 fiberflat corr"]
+        "obstime", "smjd", "tile_id", "exposure", "scira", "scidec",
+        f"{channel} fiberflat gcoeff1", f"{channel} fiberflat gcoeff2", f"{channel} fiberflat gcoeff3", f"{channel} fiberflat gcoeff4",
+        f"{channel} fiberflat factor1", f"{channel} fiberflat factor2", f"{channel} fiberflat factor3"]
 
     metadata_row = {k.replace(" ", "_"): header.get(k) for k in columns}
     metadata_sky = sky.sky_pars_header(header)
@@ -136,11 +139,14 @@ def _read_ffactors(drpver, channel):
     return pd.DataFrame(metadata)
 
 
-def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=20.0,
-                      fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
-                      groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
-                      fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False,
-                      use_untagged_cals=False, version_cals=None, display_plots=False, dry_run=False):
+def measure_fiberflat_factors(mjd, drpver, channel, expnums=None, sky_cwaves=SKYLINES_FIBERFLAT, cont_cwaves=CONTINUUM_FIBERFLAT, dwave=20.0,
+                              fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
+                              groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
+                              fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False,
+                              use_untagged_cals=False, version_cals=None, display_plots=False, dry_run=False):
+
+    if channel not in "brz":
+        log.error(f"Invalid value for `channel`: {channel}. Expected one of 'brz'")
 
     if use_untagged_cals and version_cals is None:
         log.error(f"Invalid value for `version_cals`: {version_cals}. Expected a long-term calibration version tag, .e.g, '1.2.2dev'")
@@ -161,16 +167,16 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         return pd.read_csv(table_path)
 
     # grab all relevant DRP products: before/ after fiber flat fielding
-    channel_ = "?" if channel == "all" else channel
-    wframe_paths = sorted(
-        path.expand("lvm_anc", drpver=drpver, tileid="*", mjd=mjd, expnum="????????", imagetype="object", kind="w", camera=channel_),
-        key=lambda s: int(os.path.basename(s).split(".")[0].split("-")[-1]))
+    wframe_paths = path.expand("lvm_anc", drpver=drpver, tileid="*", mjd=mjd, expnum="????????", imagetype="object", kind="w", camera=channel)
+    if expnums is not None:
+        wframe_paths = filter(lambda s: int(os.path.basename(s).split(".")[0].split("-")[-1]) in expnums, wframe_paths)
+    wframe_paths = sorted(wframe_paths, key=lambda s: int(os.path.basename(s).split(".")[0].split("-")[-1]))
 
     if len(wframe_paths) == 0:
-        log.error(f"zero paths matched given {drpver = }, {mjd = }, channel = {channel_}; nothing to do")
+        log.error(f"zero paths matched given {drpver = }, {mjd = }, {channel = }; nothing to do")
         return
 
-    log.info(f"going to estimate flat field factors for {len(wframe_paths)} frames, {mjd = }, channel = {channel_}")
+    log.info(f"going to estimate flat field factors for {len(wframe_paths)} frames, {mjd = }, channel = {channel}")
 
     # grab master fiber flat fields
     if use_untagged_cals:
@@ -194,11 +200,10 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
             metadata.append(_extract_ffactors(channel, rss._header))
             continue
 
-        channel_current = rss._header["CCD"][0]
         expnum = rss._header["EXPOSURE"]
-        sky_cwave = sky_lines[channel_current]
-        cont_cwave = CONTINUUM_FIBERFLAT[channel_current]
-        mflat = RSS.from_file(mflat_paths[channel_current])
+        sky_cwave = sky_cwaves[channel]
+        cont_cwave = cont_cwaves[channel]
+        mflat = RSS.from_file(mflat_paths[channel])
 
         fig = plt.figure(figsize=(14,3*2))
         fig.suptitle(f"Fiber flatfield correction for {expnum = } {channel = } around sky line @ {sky_cwave:.2f} Angstroms", fontsize="xx-large")
@@ -219,9 +224,6 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
             fixed_coeffs=[3] if fit_gradient else [1, 2, 3],
             groupby=groupby, axs=axs, labels=True)
 
-        log.info("evaluating gradient model")
-        gradient_model = IFUGradient.ifu_gradient(coeffs, x=x, y=y, normalize=True)
-
         log.info("applying flatfield correction")
         fiber_groups = mflat._get_fiber_groups(by="spec")
         flatfield_corr = IFUGradient.ifu_factors(factor, fiber_groups)
@@ -229,21 +231,23 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         rss /= mflat
         skyline_slit /= flatfield_corr
 
-        # update pixel mask
-        rss._mask = np.isnan(rss._data)|np.isnan(rss._error)
-
         ax_cor = fig.add_subplot(gs_cor[-1, :])
         ax_cor.set_title(f"Flatfielded skyline @ {sky_cwave:.2f}+/-{dwave:.2f} Angstroms", loc="left")
         ax_cor.set_xlabel("Fiber ID", fontsize="large")
         ax_cor.set_ylabel("Normalized counts", fontsize="large")
         ax_cor.set_ylim(0.92, 1.08)
         slit(x=rss._slitmap["fiberid"].data, y=skyline_slit, data=rss._data, ax=ax_cor)
-        save_fig(fig, product_path=f"{table_path.replace('.csv', '')}-{expnum:>08d}.fits", figure_path="qa", to_display=display_plots)
+        save_fig(fig, product_path=wframe_path, figure_path="qa", label="fiberflat_correction", to_display=display_plots)
 
-        rss._header[f"HIERARCH {channel.upper()} FIBERFLAT GRAD"] = (np.round(bn.nanmax(gradient_model)/bn.nanmin(gradient_model), 5), "fiberflat field gradient")
-        rss._header[f"HIERARCH {channel.upper()}1 FIBERFLAT CORR"] =  (np.round(factor[0], 5), "fiberflat corr. spec. 1")
-        rss._header[f"HIERARCH {channel.upper()}2 FIBERFLAT CORR"] =  (np.round(factor[1], 5), "fiberflat corr. spec. 2")
-        rss._header[f"HIERARCH {channel.upper()}3 FIBERFLAT CORR"] =  (np.round(factor[2], 5), "fiberflat corr. spec. 3")
+        rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
+        rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
+        rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT COADD", coadd_method, "coadding method")
+        rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
+        rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
+        for i, f in enumerate(factor):
+            rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", np.round(f, 5), f"fiberflat factor {groupby}{i+1}")
+        for i, c in enumerate(coeffs):
+            rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
 
         # extract flat field factors and additional information
         metadata.append(_extract_ffactors(channel, rss._header))
@@ -900,7 +904,10 @@ def get_epoch(mjd, epochs, epochs_kind, error_on_missing_mjd=True):
         "ffactor": ["science", "twilight"]
     }
 
-    epoch = epochs[mjd] if error_on_missing_mjd else epochs.get(mjd, {})
+    try:
+        epoch = epochs[mjd] if error_on_missing_mjd else epochs.get(mjd, {})
+    except KeyError:
+        raise KeyError(f"Invalid {epochs_kind} epoch `mjd`: {mjd}. Expected one of {list(epochs.keys())}")
 
     flavors = epoch.get("flavors")
     if flavors is None:
@@ -2134,61 +2141,79 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
             in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
 
-def create_fiberflats_corrections(cals_mjd: int, science_mjds: Union[int, List[int]], science_expnums: List[int] = None,
-                                  sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT, cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
-                                  groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0), sky_fibers_only: bool = False,
-                                  nsigma: float = 2.0, comb_method: str = "median", fit_gradient: bool = False, force_correction: bool = False,
-                                  undo_correction: bool = False, skip_done: bool = False, display_plots: bool = False, dry_run: bool = False) -> None:
+def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epochs, sky_cwaves=SKYLINES_FIBERFLAT, cont_cwaves=CONTINUUM_FIBERFLAT, dwave=10.0,
+                                  fiber_radius=1.0, oversampling_factor=100, quantiles=(5.0, 97.0),
+                                  groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
+                                  fit_gradient=False, use_science=True, skip_done=False, undo_correction=False, display_plots=True, dry_run=False):
 
-    if not all([cals_mjd <= sci_mjd for sci_mjd in science_mjds]):
-        log.error(f"some science MJDs are earlier than {cals_mjd = }: {science_mjds = }")
-        return
+    if not use_science:
+        raise NotImplementedError("Twilight fiber flat corrections are not implemented yet")
 
-    science_mjds = [science_mjds] if isinstance(science_mjds, int) else science_mjds
-    frames = pd.concat([md.get_frames_metadata(mjd=mjd).query("tileid != 11111 and qaqual != 'BAD'") for mjd in science_mjds], ignore_index=True)
-    if science_expnums is None:
-        science_expnums = frames.sort_values("expnum").drop_duplicates("expnum").expnum
-    else:
-        frames = frames.query("expnum in @science_expnums")
+    # determine the source MJDs for the `mjd` ffactor epoch
+    ffactor_epoch = get_epoch(mjd=mjd, epochs=ffactor_epochs, epochs_kind="ffactor", error_on_missing_mjd=True)
+    science_mjds = ffactor_epoch.get("science")
+    twilight_mjds = ffactor_epoch.get("twilight")
 
-    calibs = get_calib_paths(mjd=cals_mjd, version=drpver, flavors=CALIBRATION_NEEDS["object"], from_sandbox=False)
+    # determine the range of calibration epochs to be corrected
+    mjds = list(ffactor_epochs.keys())
+    i = mjds.index(mjd)
+    calibration_mjds = list(filter(lambda mjd: mjds[i] <= mjd < mjds[i+1], calibration_epochs.keys()))
+    mflat_paths = {mjd: get_calib_paths(mjd=mjd, version=drpver, from_sandbox=False, only_existing=True).get("fiberflat_twilight", {}).get(channel)}
 
-    if dry_run:
-        _log_dry_run(frames, calibs=calibs, settings=None, caller=create_fiberflats_corrections.__name__)
-        return
+    # undo correction
+    for mjd in calibration_mjds:
+        mflat_path = mflat_paths.get(mjd)
+        if mflat_path is None:
+            warnings.warn(f"master fiber flat for epoch {mjd = } and {channel = } not found, skipping")
+            continue
+
+        undo_ffactor_correction(in_mflat=mflat_path, write_output=True)
 
     if undo_correction:
-        for channel in "brz":
-            fit_skyline_flatfield(
-                in_sciences=[],
-                in_mflat=calibs["fiberflat_twilight"][channel],
-                out_mflat=calibs["fiberflat_twilight"][channel],
-                sky_cwave=sky_cwaves[channel], cont_cwave=cont_cwaves[channel],
-                undo_correction=undo_correction)
         return
 
-    # 2D and 1D reduction of science exposures
-    for sci_mjd in science_mjds:
-        reduce_2d(mjds=sci_mjd, calibrations=calibs, expnums=science_expnums, reject_cr=True, add_astro=True, sub_straylight=True, skip_done=skip_done)
-        reduce_1d(mjd=sci_mjd, calibrations=calibs, expnums=science_expnums, sub_straylight=True, skip_done=skip_done)
+    # determine exposures to be used for factors fitting
+    source_mjds = science_mjds if use_science else twilight_mjds
+    for mjd in source_mjds:
+        calibs = get_calib_paths(mjd, version=drpver, from_sandbox=False)
 
-    for channel in "brz":
-        wframe_paths = get_frames_paths(mjds=science_mjds, kind="w", camera_or_channel=channel, expnums=science_expnums)
-        if len(wframe_paths) == 0:
-            log.error(f"no good quality science frames found for {science_mjds = }, {science_expnums = } in {channel = }")
+        if use_science:
+            expnums = md.get_frames_metadata(mjd).query("tileid != 11111 and qaqual != 'BAD'").expnum.unique()
+        else:
+            expnums = md.get_calibrations_metadata(mjds=mjd, calibration="twilight").expnum.unique()
 
-        fit_skyline_flatfield(
-            in_sciences=wframe_paths,
-            in_mflat=calibs["fiberflat_twilight"][channel],
-            out_mflat=calibs["fiberflat_twilight"][channel],
-            groupby=groupby,
-            guess_coeffs=[1,0,0,0], fixed_coeffs=[3] if fit_gradient else [1, 2, 3],
-            sky_cwave=sky_cwaves[channel], cont_cwave=cont_cwaves[channel], dwave=20.0,
-            quantiles=quantiles, sky_fibers_only=sky_fibers_only,
-            nsigma=nsigma, comb_method=comb_method,
-            force_correction=force_correction,
-            undo_correction=undo_correction,
-            display_plots=display_plots)
+    if dry_run:
+        log.info(f"going to create fiber flat factors for channel {channel} using {'science' if use_science else 'twilight'} exposures from mjds: {source_mjds}")
+        log.info(f"selected exposures: {expnums}")
+        log.info(f"corrected calibration epochs: {calibration_mjds}")
+        return
+
+    # perform 2D, 1D reductions, down to wavelength calibrated products
+    for mjd in source_mjds:
+        # reduce science/twilight exposures down to wavelength calibration step
+        reduce_2d(mjds=mjd, calibrations=calibs, expnums=expnums, add_astro=use_science, sub_straylight=True, skip_done=skip_done)
+        reduce_1d(mjd=mjd, calibrations=calibs, expnums=expnums, sub_straylight=True, skip_done=skip_done)
+
+    ffactors = []
+    for mjd in source_mjds:
+        ffactors.append(measure_fiberflat_factors(mjd=mjd, drpver=drpver, channel=channel, expnums=expnums,
+                        sky_cwaves=sky_cwaves, cont_cwaves=cont_cwaves, dwave=dwave,
+                        fiber_radius=fiber_radius, oversampling_factor=oversampling_factor,
+                        quantiles=quantiles, groupby=groupby, coadd_method=coadd_method,
+                        norm_stat=norm_stat, fit_gradient=fit_gradient, write_table=False,
+                        use_untagged_cals=True, version_cals=drpver, display_plots=display_plots))
+
+    ffactors = pd.concat(ffactors, ignore_index=True)
+    factor = ffactors.filter(like="factor").sort_index(axis="columns").apply(lambda x: biweight_location(x, ignore_nan=True), axis="index").values
+    coeffs = ffactors.filter(like="gcoeff").sort_index(axis="columns").apply(lambda x: biweight_location(x, ignore_nan=True), axis="index").values
+
+    for mjd in calibration_mjds:
+        mflat_path = mflat_paths.get(mjd)
+        if mflat_path is None:
+            warnings.warn(f"master fiber flat for epoch {mjd = } and {channel = } not found, skipping correction")
+            continue
+
+        do_ffactor_correction(in_mflat=mflat_path, coeffs=coeffs, factor=factor, sky_cwave=sky_cwaves[channel], dwave=dwave, coadd_method=coadd_method, write_output=True)
 
 
 def create_illumination_corrections(mjd, use_longterm_cals=True, expnums=None):

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -130,7 +130,11 @@ def _read_ffactors(drpver, channel):
 def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=20.0,
                       fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
                       groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
-                      fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False, display_plots=False):
+                      fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False,
+                      display_plots=False, dry_run=False):
+    if mjd is None:
+        log.error("no MJD given, nothing to do")
+        return
     # define label if not given
     label = label or "".join(filter(str.isalnum, norm_stat.__name__))
 
@@ -149,6 +153,12 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         key=lambda s: int(os.path.basename(s).split(".")[0].split("-")[-1]))
 
     if len(wframe_paths) == 0:
+        log.error(f"zero paths matched given {drpver = }, {mjd = }, channel = {channel_}; nothing to do")
+        return
+
+    log.info(f"going to estimate flat field factors for {len(wframe_paths)} frames, {mjd = }, channel = {channel_}")
+    if dry_run:
+        log.info(f"output table at {table_path}")
         return
 
     # grab master fiber flat fields
@@ -219,6 +229,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
     metadata = pd.DataFrame(metadata)
     metadata.sort_values("exposure", inplace=True)
     if write_table:
+        log.info(f"saving output table at {table_path}")
         metadata.to_csv(table_path, index=False)
 
     return metadata

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -170,7 +170,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         cals_mjd = mjd
     mflat_paths = get_calib_paths(mjd=cals_mjd, from_sandbox=not use_untagged_cals, version=version_cals)["fiberflat_twilight"]
     if dry_run:
-        log.info(f"using calibrations:")
+        log.info("using calibrations:")
         for channel in mflat_paths:
             log.info(f"  {channel = }: {mflat_paths[channel]}")
         log.info(f"output table at {table_path}")
@@ -338,7 +338,7 @@ def choose_sequence(frames, calibration, ref_mjd=None, kind="longterm", ring="pr
     ref_mjd : int, optional
         Reference MJD around which a sequence will be chosen, by default None
     kind : str, optional
-        Calibration sequence length, either 'nightly' (short) or 'longterm' (long), by default "longterm"
+        Calibration sequence length, either 'nightly' (short), 'longterm' (long), by default "longterm" or None
     ring : str, optional
         Standard fibers ring to select, either 'primary', 'secondary', 'both'. By default 'primary'
 
@@ -364,8 +364,12 @@ def choose_sequence(frames, calibration, ref_mjd=None, kind="longterm", ring="pr
         raise ValueError(f"Invalid value for `ring`: {ring}. Expected either 'primary', 'secondary' or 'both'")
     if not isinstance(calibration, str) or calibration not in CALIBRATION_TYPES:
         raise ValueError(f"Invalid value for `calibration`: {calibration}. Expected one of {','.join(CALIBRATION_TYPES)}")
-    if not isinstance(kind, str) or kind not in {"nightly", "longterm"}:
+    if kind is not None and (not isinstance(kind, str) or kind not in {"nightly", "longterm"}):
         raise ValueError(f"Invalid value for `kind`: {kind}. Expected either 'longterm' or 'nightly'")
+
+    # skip sequence selection if
+    if kind is None:
+        return frames, frames.expnum.unique()
 
     nstandards = 12 if ring in {"primary", "secondary"} else 24
     EXPECTED_SEQUENCE_LENGTH = {
@@ -1835,6 +1839,8 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
                       cnorms: Dict[str, float] = SKYLINES_FIBERFLAT, dwave: float = 20.0,
                       smoothing: float = 0.07,
                       interpolate_invalid: bool = True,
+                      skip_sequence_selection: bool = False,
+                      skip_combination: bool = False,
                       skip_done: bool = False,
                       display_plots: bool = False,
                       dry_run: bool = False) -> None:
@@ -1880,7 +1886,7 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
     mjds = epoch["twilight"]
 
     frames = md.get_calibrations_metadata(mjds=mjds, calibration="twilight")
-    frames, expnums = choose_sequence(frames, calibration="twilight", kind="longterm")
+    frames, expnums = choose_sequence(frames, calibration="twilight", kind=None if skip_sequence_selection else "longterm")
     if frames.empty:
         log.error("no twilight frames found, skipping production of twilight fiberflats")
         return
@@ -1958,6 +1964,12 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
                           ref_kind=ref_kind, groupby=groupby, guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs,
                           norm_cwave=cnorms[channel], norm_dwave=dwave, smoothing=smoothing, interpolate_invalid=interpolate_invalid,
                           display_plots=display_plots)
+
+
+        # skip creation of master fiberflats
+        if skip_combination:
+            log.info("skipping creation of master fiberflat")
+            return
 
         # combine individual fiberflats into master fiberflat
         mflat_path = path.full("lvm_master", drpver=drpver, tileid=11111, mjd=mjd, kind="mfiberflat_twilight", camera=channel)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -49,7 +49,7 @@ from lvmdrp import log, path, __version__ as drpver
 from lvmdrp.utils import metadata as md
 from lvmdrp.utils import hdrfix
 from lvmdrp.utils.convert import tileid_grp
-from lvmdrp.utils.paths import get_calib_paths, group_calib_paths, get_frames_paths
+from lvmdrp.utils.paths import get_calib_paths, group_calib_paths, get_frames_paths, get_master_mjd
 from lvmdrp.utils import pixshifts
 from lvmdrp.core.plot import save_fig, slit
 from lvmdrp.core import dataproducts as dp
@@ -164,11 +164,15 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
     log.info(f"going to estimate flat field factors for {len(wframe_paths)} frames, {mjd = }, channel = {channel_}")
 
     # grab master fiber flat fields
-    mflat_paths = get_calib_paths(mjd=mjd, from_sandbox=not use_untagged_cals, version=version_cals)["fiberflat_twilight"]
+    if use_untagged_cals:
+        cals_mjd = get_master_mjd(mjd)
+    else:
+        cals_mjd = mjd
+    mflat_paths = get_calib_paths(mjd=cals_mjd, from_sandbox=not use_untagged_cals, version=version_cals)["fiberflat_twilight"]
     if dry_run:
         log.info(f"using calibrations:")
         for channel in mflat_paths:
-            log.info(f"{channel = }: {mflat_paths[channel]}")
+            log.info(f"  {channel = }: {mflat_paths[channel]}")
         log.info(f"output table at {table_path}")
         return
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -735,7 +735,7 @@ def _parse_list(items_str):
     return items
 
 
-def update_fflat_epochs(ffactor_epoch_path=None, calibration_epoch_path=None, max_mjd=62000):
+def update_fflat_epochs(ffactor_epoch_path=None, calibration_epoch_path=None, n_nights=None, max_mjd=62000):
     """Update the fiber flat factor epoch definitions from calibration epochs.
 
     Parameters
@@ -746,6 +746,12 @@ def update_fflat_epochs(ffactor_epoch_path=None, calibration_epoch_path=None, ma
     calibration_epoch_path : pathlib.Path or None, optional
         Path to the calibration epochs YAML file. If None, the default path
         from ``EPOCHS_FILE_PATH["calibration"]`` is used.
+    n_nights : int or None, optional
+        Maximum number of nights that should be included in each fiber-flat
+        factor epoch. If provided, intervals between the selected calibration
+        boundaries are split into chunks of at most this size.
+    max_mjd : int, optional
+        Maximum MJD to include when building the factor epochs.
 
     Returns
     -------
@@ -763,7 +769,11 @@ def update_fflat_epochs(ffactor_epoch_path=None, calibration_epoch_path=None, ma
     calibration_epoch_path = calibration_epoch_path or EPOCHS_FILE_PATH["calibration"]
     ffactor_epoch_path = ffactor_epoch_path or EPOCHS_FILE_PATH["ffactor"]
 
-    calibration_epochs = load_epochs_file(epochs_kind="calibration", verbose=False)
+    if n_nights is not None and (not isinstance(n_nights, (int, np.integer)) or n_nights < 1):
+        raise ValueError(f"`n_nights` must be a positive integer; got {n_nights!r}")
+    n_nights = 999 if n_nights is None else n_nights
+
+    calibration_epochs = load_epochs_file(epochs_kind="calibration", epochs_path=calibration_epoch_path, verbose=False)
 
     # locate early science start
     mjd_early = list(calibration_epochs.keys())[:1]
@@ -788,12 +798,13 @@ def update_fflat_epochs(ffactor_epoch_path=None, calibration_epoch_path=None, ma
     }
     epochs = {}
     for i, mjd in enumerate(mjds[:-1]):
+        mjd_end = min(mjd + n_nights, mjds[i + 1]) - 1
         epochs[mjd] = {
             "flavors": {
-                "science": f"{mjds[i]}-{mjds[i+1]-1}",
-                "twilight": f"{mjds[i]}-{mjds[i+1]-1}"
+                "science": f"{mjd}-{mjd_end}",
+                "twilight": f"{mjd}-{mjd_end}"
             },
-            "trigger": None,
+            "trigger": calibration_epochs.get(mjd, {}).get("trigger"),
             "comment": None
         }
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -114,13 +114,12 @@ EPOCHS_FILE_PATH = {
     }
 
 
-def _extract_ffactors(channel, header):
-    columns = [
-        "obstime", "smjd", "tile_id", "exposure", "scira", "scidec",
-        f"{channel} fiberflat gcoeff1", f"{channel} fiberflat gcoeff2", f"{channel} fiberflat gcoeff3", f"{channel} fiberflat gcoeff4",
-        f"{channel} fiberflat factor1", f"{channel} fiberflat factor2", f"{channel} fiberflat factor3"]
+def _extract_ffactors(header):
+    columns = ["obstime", "smjd", "tile_id", "exposure", "scira", "scidec"]
+    columns += sorted(header["*gcoeff?"].keys())
+    columns += sorted(header["*factor?"].keys())
 
-    metadata_row = {k.replace(" ", "_"): header.get(k) for k in columns}
+    metadata_row = {k.replace(" ", "_").lower(): header.get(k) for k in columns}
     metadata_sky = sky.sky_pars_header(header)
     metadata_sky = {k.split()[-1].lower().replace("sci_", ""): v[0] for k, v in metadata_sky.items() if "SKYE_" not in k and "SKYW_" not in k}
     metadata_row.update(metadata_sky)
@@ -135,7 +134,7 @@ def _read_ffactors(drpver, channel):
     for p in tqdm(frame_paths, desc=f"extracting factors for {drpver = } | {channel = }", ascii=True, unit="exposure"):
         hdr = fits.getheader(p)
 
-        metadata.append(_extract_ffactors(channel, hdr))
+        metadata.append(_extract_ffactors(hdr))
     return pd.DataFrame(metadata)
 
 
@@ -144,6 +143,67 @@ def measure_fiberflat_factors(mjd, drpver, channel, expnums=None, sky_cwaves=SKY
                               groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
                               fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False,
                               use_untagged_cals=False, version_cals=None, display_plots=False, dry_run=False):
+    """Measure fiberflat correction factors from science or twilight exposures.
+
+    The function inspects wavelength-calibrated frame products, estimates
+    skyline-based flatfield factors for each exposure using the current master
+    twilight fiberflat, and stores the fitted correction coefficients and
+    factors in a table for later use in master fiberflat corrections.
+
+    Parameters
+    ----------
+    mjd : int
+        MJD of the exposures to analyze.
+    drpver : str
+        DRP version tag used to locate input products.
+    channel : str
+        Spectrograph channel to process, one of ``"b"``, ``"r"``, or ``"z"``.
+    expnums : sequence of int, optional
+        Restrict the analysis to a specific set of exposure numbers.
+    sky_cwaves : dict, optional
+        Central wavelengths for skyline-based measurements per channel.
+    cont_cwaves : dict, optional
+        Central wavelengths for continuum regions used during factor fitting.
+    dwave : float, optional
+        Wavelength window width used for the measurement.
+    fiber_radius : float, optional
+        Fiber radius used by the skyline flatfield measurement.
+    oversampling_factor : int, optional
+        Oversampling factor used in the measurement.
+    quantiles : tuple of float, optional
+        Quantiles used for robust normalization in the fitting process.
+    groupby : str, optional
+        Fiber grouping used when fitting the correction factors.
+    coadd_method : str, optional
+        Coaddition method used during the skyline flatfield measurement.
+    norm_stat : callable, optional
+        Robust statistic used to normalize the measured factors.
+    fit_gradient : bool, optional
+        Whether to fit an IFU gradient component in addition to the factors.
+    label : str, optional
+        Label used to name the output table.
+    write_table : bool, optional
+        Whether to save the fitted factors to a CSV table.
+    table_dir : str, optional
+        Directory where the output table should be written.
+    overwrite : bool, optional
+        Whether to overwrite an existing output table.
+    use_untagged_cals : bool, optional
+        Whether to use the long-term calibration master fiberflat for the
+        requested MJD.
+    version_cals : str, optional
+        Calibration version tag to use when locating master fiberflats.
+    display_plots : bool, optional
+        Whether to display diagnostic plots produced during the measurement.
+    dry_run : bool, optional
+        Whether to print the planned inputs and skip the computation.
+
+    Returns
+    -------
+    pandas.DataFrame or None
+        A table of fitted fiberflat factors and gradient coefficients for the
+        analyzed exposures, or ``None`` if no valid frames were found.
+    """
 
     if channel not in "brz":
         log.error(f"Invalid value for `channel`: {channel}. Expected one of 'brz'")
@@ -197,7 +257,7 @@ def measure_fiberflat_factors(mjd, drpver, channel, expnums=None, sky_cwaves=SKY
         rss = RSS.from_file(wframe_path)
 
         if "ON" in [rss._header[lamp] for lamp in ARC_LAMPS + CON_LAMPS]:
-            metadata.append(_extract_ffactors(channel, rss._header))
+            metadata.append(_extract_ffactors(rss._header))
             continue
 
         expnum = rss._header["EXPOSURE"]
@@ -250,7 +310,7 @@ def measure_fiberflat_factors(mjd, drpver, channel, expnums=None, sky_cwaves=SKY
             rss.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
 
         # extract flat field factors and additional information
-        metadata.append(_extract_ffactors(channel, rss._header))
+        metadata.append(_extract_ffactors(rss._header))
 
     metadata = pd.DataFrame(metadata)
     metadata.sort_values("exposure", inplace=True)
@@ -2145,6 +2205,62 @@ def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epoc
                                   fiber_radius=1.0, oversampling_factor=100, quantiles=(5.0, 97.0),
                                   groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
                                   fit_gradient=False, use_science=True, skip_done=False, undo_correction=False, display_plots=True, dry_run=False):
+    """Create and apply fiberflat correction factors to master twilight flats.
+
+    The routine determines the relevant ffactor epoch, removes any existing
+    corrections from the affected master fiberflats when requested, reduces the
+    required science or twilight exposures to the wavelength-calibrated stage,
+    measures robust correction factors, and writes the corrected master
+    fiberflats back to disk.
+
+    Parameters
+    ----------
+    mjd : int
+        Reference MJD for the calibration epoch to correct.
+    channel : str
+        Spectrograph channel to process.
+    ffactor_epochs : dict
+        Definitions of the ffactor epochs and the associated science/twilight
+        MJDs.
+    calibration_epochs : dict
+        Calibration epoch definitions that should receive the correction.
+    sky_cwaves : dict, optional
+        Central wavelengths for the skyline-based correction per channel.
+    cont_cwaves : dict, optional
+        Central wavelengths for the continuum-based correction per channel.
+    dwave : float, optional
+        Wavelength window width used when measuring the correction factors.
+    fiber_radius : float, optional
+        Fiber radius used in the 2D extraction and fitting steps.
+    oversampling_factor : int, optional
+        Oversampling factor used for the correction measurement.
+    quantiles : tuple of float, optional
+        Quantiles used for robust normalization during factor fitting.
+    groupby : str, optional
+        Fiber grouping used by the correction model.
+    coadd_method : str, optional
+        Coaddition method used when fitting the factors.
+    norm_stat : callable, optional
+        Robust statistic used to combine the measured factors.
+    fit_gradient : bool, optional
+        Whether to fit an IFU gradient component in addition to the factors.
+    use_science : bool, optional
+        Whether to derive the factors from science exposures instead of twilight
+        exposures.
+    skip_done : bool, optional
+        Whether to skip processing steps that have already been completed.
+    undo_correction : bool, optional
+        Whether to remove existing corrections without recomputing them.
+    display_plots : bool, optional
+        Whether to display diagnostic plots during factor measurement.
+    dry_run : bool, optional
+        Whether to log the planned actions without performing the reduction.
+
+    Returns
+    -------
+    None
+        The function writes corrected master fiberflats to disk.
+    """
 
     if not use_science:
         raise NotImplementedError("Twilight fiber flat corrections are not implemented yet")
@@ -2174,13 +2290,12 @@ def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epoc
 
     # determine exposures to be used for factors fitting
     source_mjds = science_mjds if use_science else twilight_mjds
+    expnums = []
     for mjd in source_mjds:
-        calibs = get_calib_paths(mjd, version=drpver, from_sandbox=False)
-
         if use_science:
-            expnums = md.get_frames_metadata(mjd).query("tileid != 11111 and qaqual != 'BAD'").expnum.unique()
+            expnums.extend(md.get_frames_metadata(mjd).query("tileid != 11111 and qaqual != 'BAD'").expnum.unique())
         else:
-            expnums = md.get_calibrations_metadata(mjds=mjd, calibration="twilight").expnum.unique()
+            expnums.extend(md.get_calibrations_metadata(mjds=mjd, calibration="twilight").expnum.unique())
 
     if dry_run:
         log.info(f"going to create fiber flat factors for channel {channel} using {'science' if use_science else 'twilight'} exposures from mjds: {source_mjds}")
@@ -2190,6 +2305,9 @@ def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epoc
 
     # perform 2D, 1D reductions, down to wavelength calibrated products
     for mjd in source_mjds:
+        # get calibration paths from untagged epochs
+        calibs = get_calib_paths(get_master_mjd(mjd), version=drpver, from_sandbox=False)
+
         # reduce science/twilight exposures down to wavelength calibration step
         reduce_2d(mjds=mjd, calibrations=calibs, expnums=expnums, add_astro=use_science, sub_straylight=True, skip_done=skip_done)
         reduce_1d(mjd=mjd, calibrations=calibs, expnums=expnums, sub_straylight=True, skip_done=skip_done)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1833,7 +1833,7 @@ def create_dome_fiberflats(mjd, expnums_ldls=None, expnums_qrtz=None, cals_mjd=N
         lvmflat.writeFitsData(path.full("lvm_frame", mjd=mjd, tileid=11111, drpver=drpver, expnum=expnum_str, kind=f'DFlat-{channel}'))
 
 
-def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mjd: int = None, use_longterm_cals: bool = True,
+def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mjd: int = None, channels: str = "brz",
                       ref_kind: Union[int, Callable[[np.ndarray, int], np.ndarray]] = bn.nanmedian,
                       groupby: str = "spec", guess_coeffs: List[int] = [1,0,0,0], fixed_coeffs: List[int] = [3],
                       cnorms: Dict[str, float] = SKYLINES_FIBERFLAT, dwave: float = 20.0,
@@ -1882,6 +1882,11 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
     dry_run : bool, optional
         Logs useful information abaut the current setup without actually reducing, by default False
     """
+
+    _channels = set(channels)
+    if not _channels.issubset(set("brz")):
+        raise ValueError(f"Invalid value in `channels`: {channels}. Expected a subset of 'brz'")
+
     epoch = get_calibration_epoch(mjd=mjd, **(epochs or {}).get(mjd, {}))
     mjds = epoch["twilight"]
 
@@ -1923,9 +1928,8 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
         calibs[flavor] = group_calib_paths(calibs[flavor])
 
     # decompose twilight spectra into sun continuum and twilight components
-    channels = "brz"
     flat_channels = frames.groupby(frames.camera.str.__getitem__(0))
-    for channel in channels:
+    for channel in _channels:
         flat_expnums = flat_channels.get_group(channel).groupby("expnum")
         xtwi_paths, fflat_paths, lvmflat_paths = [], [], []
         for expnum in flat_expnums.groups:
@@ -1968,8 +1972,8 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
 
         # skip creation of master fiberflats
         if skip_combination:
-            log.info("skipping creation of master fiberflat")
-            return
+            log.info(f"skipping creation of master fiberflat for {channel = }")
+            continue
 
         # combine individual fiberflats into master fiberflat
         mflat_path = path.full("lvm_master", drpver=drpver, tileid=11111, mjd=mjd, kind="mfiberflat_twilight", camera=channel)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1984,25 +1984,37 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
             in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
 
-def create_fiberflats_corrections(cals_mjd: int, science_mjds: Union[int, List[int]], use_longterm_cals: bool = True, science_expnums: List[int] = None,
+def create_fiberflats_corrections(cals_mjd: int, science_mjds: Union[int, List[int]], science_expnums: List[int] = None,
                                   sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT, cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
                                   groupby: str = "spec", quantiles: Tuple[float, float] = (5.0, 97.0), sky_fibers_only: bool = False,
-                                  nsigma: float = 2.0, comb_method: str = "median", force_correction: bool = False,
-                                  skip_done: bool = False, display_plots: bool = False, dry_run: bool = False) -> None:
+                                  nsigma: float = 2.0, comb_method: str = "median", fit_gradient: bool = False, force_correction: bool = False,
+                                  undo_correction: bool = False, skip_done: bool = False, display_plots: bool = False, dry_run: bool = False) -> None:
 
     if not all([cals_mjd <= sci_mjd for sci_mjd in science_mjds]):
         log.error(f"some science MJDs are earlier than {cals_mjd = }: {science_mjds = }")
         return
 
     science_mjds = [science_mjds] if isinstance(science_mjds, int) else science_mjds
+    frames = pd.concat([md.get_frames_metadata(mjd=mjd).query("tileid != 11111 and qaqual != 'BAD'") for mjd in science_mjds], ignore_index=True)
     if science_expnums is None:
-        frames = pd.concat([md.get_frames_metadata(mjd=mjd).query("tileid != 11111 and qaqual != 'BAD'") for mjd in science_mjds], ignore_index=True)
         science_expnums = frames.sort_values("expnum").drop_duplicates("expnum").expnum
+    else:
+        frames = frames.query("expnum in @science_expnums")
 
     calibs = get_calib_paths(mjd=cals_mjd, version=drpver, flavors=CALIBRATION_NEEDS["object"], from_sandbox=False)
 
     if dry_run:
         _log_dry_run(frames, calibs=calibs, settings=None, caller=create_fiberflats_corrections.__name__)
+        return
+
+    if undo_correction:
+        for channel in "brz":
+            fit_skyline_flatfield(
+                in_sciences=[],
+                in_mflat=calibs["fiberflat_twilight"][channel],
+                out_mflat=calibs["fiberflat_twilight"][channel],
+                sky_cwave=sky_cwaves[channel], cont_cwave=cont_cwaves[channel],
+                undo_correction=undo_correction)
         return
 
     # 2D and 1D reduction of science exposures
@@ -2020,11 +2032,12 @@ def create_fiberflats_corrections(cals_mjd: int, science_mjds: Union[int, List[i
             in_mflat=calibs["fiberflat_twilight"][channel],
             out_mflat=calibs["fiberflat_twilight"][channel],
             groupby=groupby,
-            guess_coeffs=[1,0,0,0], fixed_coeffs=[0,1,2,3],
+            guess_coeffs=[1,0,0,0], fixed_coeffs=[3] if fit_gradient else [1, 2, 3],
             sky_cwave=sky_cwaves[channel], cont_cwave=cont_cwaves[channel], dwave=20.0,
             quantiles=quantiles, sky_fibers_only=sky_fibers_only,
             nsigma=nsigma, comb_method=comb_method,
             force_correction=force_correction,
+            undo_correction=undo_correction,
             display_plots=display_plots)
 
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -26,6 +26,7 @@
 #
 
 import os
+import pathlib
 import yaml
 import warnings
 import numpy as np
@@ -100,7 +101,15 @@ FIBER_SMOOTHING_CONFIG = {
     "sigmas": ("polynomial", {"deg": 8, "nsigmas": np.inf, "min_samples_frac": 0.7})}
 
 
-CALIBRATION_EPOCHS_PATH = os.path.join(os.getenv("LVMCORE_DIR"), "calibrations", "calibration-epochs.yaml")
+lvmcore_dir = pathlib.Path(os.getenv("LVMCORE_DIR", "."))
+FFACTOR_EPOCHS_PATH = lvmcore_dir / "calibrations" / "fiberflat-factor-epochs.yaml"
+
+CALIBRATION_EPOCHS_PATH = lvmcore_dir / "calibrations" / "calibration-epochs.yaml"
+
+EPOCHS_FILE_PATH = {
+        "ffactor": FFACTOR_EPOCHS_PATH,
+        "calibration": CALIBRATION_EPOCHS_PATH
+    }
 
 
 def _extract_ffactors(channel, header):
@@ -726,8 +735,108 @@ def _parse_list(items_str):
     return items
 
 
-def load_calibration_epochs(epochs_path=None, filter_by=None, verbose=True):
-    epochs_path = epochs_path or CALIBRATION_EPOCHS_PATH
+def update_fflat_epochs(ffactor_epoch_path=None, calibration_epoch_path=None, max_mjd=62000):
+    """Update the fiber flat factor epoch definitions from calibration epochs.
+
+    Parameters
+    ----------
+    ffactor_epoch_path : pathlib.Path or None, optional
+        Path to the fiber flat factor epochs YAML file. If None, the default
+        path from ``EPOCHS_FILE_PATH["ffactor"]`` is used.
+    calibration_epoch_path : pathlib.Path or None, optional
+        Path to the calibration epochs YAML file. If None, the default path
+        from ``EPOCHS_FILE_PATH["calibration"]`` is used.
+
+    Returns
+    -------
+    None
+        The function writes or updates the YAML file in place.
+
+    Notes
+    -----
+    The function derives the relevant MJD epochs from the earliest science
+    period, the survey-start trigger, and any instrument intervention events.
+    Existing fiber flat factor epochs are preserved when the target file already
+    exists.
+    """
+
+    calibration_epoch_path = calibration_epoch_path or EPOCHS_FILE_PATH["calibration"]
+    ffactor_epoch_path = ffactor_epoch_path or EPOCHS_FILE_PATH["ffactor"]
+
+    calibration_epochs = load_epochs_file(epochs_kind="calibration", verbose=False)
+
+    # locate early science start
+    mjd_early = list(calibration_epochs.keys())[:1]
+    # locate survey start
+    mjd_start = [mjd for mjd, epoch in calibration_epochs.items() if epoch["trigger"] == "Survey start"]
+    # locate instrument intervention epochs
+    intervention_epochs = {mjd: epoch for mjd, epoch in calibration_epochs.items() if epoch["trigger"] == "Instrument intervention"}
+    mjd_interventions = list(intervention_epochs.keys())
+    # combine all relevant MJDs
+    mjds = sorted(set(mjd_early + mjd_start + mjd_interventions + [max_mjd]))
+
+    # define empty ffactor epochs
+    schema = {
+        "name": "epochs",
+        "dtype": "dict[int, dict]",
+        "description": "Dictionary mapping fiber flat factors to exposure numbers used to generate those factors, epochs are divided by 'Instrument intervention' event.",
+        "keyschmas": [
+            {"name": "flavors", "dtype": "dict[int, int|str]", "description": "Dictionary mapping frame flavors, either 'science' or 'twilight' to a list of MJDs to source from."},
+            {"name": "trigger", "dtype": "str | null", "description": "Reason for which these factors were measured, see calibration epochs `trigger`."},
+            {"name": "comment", "dtype": "str | null", "description": "Optional comment providing more context about the factors measurements."}
+        ]
+    }
+    epochs = {}
+    for i, mjd in enumerate(mjds[:-1]):
+        epochs[mjd] = {
+            "flavors": {
+                "science": f"{mjds[i]}-{mjds[i+1]-1}",
+                "twilight": f"{mjds[i]}-{mjds[i+1]-1}"
+            },
+            "trigger": None,
+            "comment": None
+        }
+
+    # create new ffactor epochs file
+    if not ffactor_epoch_path.exists():
+        with open(ffactor_epoch_path, 'w+') as f:
+            f.write(yaml.safe_dump({"schema": schema, "epochs": epochs}, sort_keys=False, indent=2))
+        return
+
+    # update existing ffactor epochs file using information in calibration epochs file
+    ffactor_epochs = load_epochs_file(epochs_kind="ffactor", verbose=False)
+    epochs.update(ffactor_epochs)
+    with open(ffactor_epoch_path, 'w+') as f:
+        f.write(yaml.safe_dump({"schema": schema, "epochs": epochs}, sort_keys=False, indent=2))
+
+
+def load_epochs_file(epochs_kind, epochs_path=None, filter_by_mjds=None, verbose=True):
+    """Load epoch definitions from a YAML file.
+
+    Parameters
+    ----------
+    epochs_kind : str
+        Kind of epoch file to load. Supported values are typically
+        ``"calibration"`` and ``"ffactor"``.
+    epochs_path : str or pathlib.Path, optional
+        Explicit path to the YAML file. If omitted, the default path is chosen
+        from ``EPOCHS_FILE_PATH[epochs_kind]``.
+    filter_by_mjds : int, tuple, list, set, numpy.ndarray, optional
+        One or more MJDs to keep from the loaded epoch mapping.
+    verbose : bool, optional
+        If True, log the loaded and filtered epoch information.
+
+    Returns
+    -------
+    dict or None
+        The epoch mapping loaded from the YAML file, or ``None`` if the file is
+        missing.
+    """
+
+    if filter_by_mjds is not None and not isinstance(filter_by_mjds, (tuple, list, set, np.ndarray)):
+        filter_by_mjds = [filter_by_mjds]
+
+    epochs_path = epochs_path or EPOCHS_FILE_PATH[epochs_kind]
     if not os.path.exists(epochs_path):
         log.error(f"calibration epochs file not found: {epochs_path}")
         return
@@ -740,21 +849,50 @@ def load_calibration_epochs(epochs_path=None, filter_by=None, verbose=True):
         for mjd in epochs:
             log.info(f"  {mjd}: {epochs[mjd]}")
 
-    if filter_by is not None and isinstance(filter_by, (list, tuple)):
-        epochs = {mjd: epochs[mjd] for mjd in filter_by if mjd in epochs}
+    if filter_by_mjds is not None:
+        epochs = {mjd: epochs[mjd] for mjd in filter_by_mjds if mjd in epochs}
         if len(epochs) == 0:
-            log.error(f"epoch(s) {filter_by} not found in calibration epochs file: '{epochs_path}'")
+            log.error(f"epoch(s) {filter_by_mjds} not found in calibration epochs file: '{epochs_path}'")
             return epochs
         if verbose:
-            log.info(f"after filtering by MJD = {filter_by}, {len(epochs)} remaining epoch(s):")
+            log.info(f"after filtering by MJD = {filter_by_mjds}, {len(epochs)} remaining epoch(s):")
             for mjd in epochs:
                 log.info(f"  {mjd}: {epochs[mjd]}")
     return epochs
 
 
-def get_calibration_epoch(mjd, flavors=None, trigger=None, comment=None):
+def get_epoch(mjd, epochs, epochs_kind, error_on_missing_mjd=True):
+    """Retrieve the source MJDs associated with a given epoch.
+
+    Parameters
+    ----------
+    mjd : int
+        Modified Julian Date identifying the epoch of interest.
+    epochs : dict
+        Mapping of MJDs to epoch metadata loaded from an epochs YAML file.
+    epochs_kind : str
+        Kind of epochs being queried. Supported values include ``"calibration"``
+        and ``"ffactor"``.
+    error_on_missing_mjd : bool, optional
+        If True, raise a ``KeyError`` when the requested MJD is absent. If
+        False, an empty mapping is returned for missing entries.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping each flavor to the corresponding source MJD(s).
+    """
+
+    _FLAVORS = {
+        "calibration": CALIBRATION_TYPES,
+        "ffactor": ["science", "twilight"]
+    }
+
+    epoch = epochs[mjd] if error_on_missing_mjd else epochs.get(mjd, {})
+
+    flavors = epoch.get("flavors")
     if flavors is None:
-        return {flavor: _parse_list(mjd) for flavor in CALIBRATION_TYPES}
+        return {flavor: _parse_list(mjd) for flavor in _FLAVORS[epochs_kind]}
 
     calibs_mjds = {flavor: _parse_list(source_mjd) for flavor, source_mjd in flavors.items()}
     return calibs_mjds
@@ -1317,7 +1455,7 @@ def validate_calibration_epochs(mjd=None, calibrations=CALIBRATION_TYPES, epochs
             log.info(f"{nstds} exposed standards{label}: {', '.join(stds)}")
 
 
-    epochs = load_calibration_epochs(epochs_path=epochs_path, verbose=False)
+    epochs = load_epochs_file(epochs_kind="calibration", epochs_path=epochs_path, verbose=False)
     if mjd is not None and mjd not in epochs:
         log.error(f"no calibrations epoch found for {mjd} in file {epochs_path}")
         return
@@ -1331,7 +1469,7 @@ def validate_calibration_epochs(mjd=None, calibrations=CALIBRATION_TYPES, epochs
 
     for mjd in epoch_mjds:
         log.info(f"validating {calibrations = } for epoch = {mjd}")
-        epoch = get_calibration_epoch(mjd, **epochs[mjd])
+        epoch = get_epoch(mjd=mjd, epochs=epochs, epochs_kind="calibration", error_on_missing_mjd=True)
         for calibration in calibrations:
             source_mjds = epoch.get(calibration, [])
             log.info(f"MJDs for {calibration = }: {', '.join(map(str, source_mjds))}")
@@ -1354,7 +1492,7 @@ def validate_calibration_epochs(mjd=None, calibrations=CALIBRATION_TYPES, epochs
 
 
 def check_epochs_completeness(mjd=None, version=drpver, calibrations=CALIBRATION_TYPES, epochs_path=CALIBRATION_EPOCHS_PATH):
-    epochs = load_calibration_epochs(epochs_path=epochs_path, verbose=False)
+    epochs = load_epochs_file(epochs_kind="calibration", epochs_path=epochs_path, verbose=False)
     if mjd is not None and mjd not in epochs:
         log.error(f"no calibrations epoch found for {mjd} in file {epochs_path}")
         return
@@ -1401,7 +1539,7 @@ def create_bias(mjd, epochs=None, use_longterm_cals=True, skip_done=True, dry_ru
     dry_run : bool, optional
         Logs useful information abaut the current setup without actually reducing, by default False
     """
-    epoch = get_calibration_epoch(mjd=mjd, **(epochs or {}).get(mjd, {}))
+    epoch = get_epoch(mjd=mjd, epochs=epochs or {}, epochs_kind="calibration", error_on_missing_mjd=False)
     mjds = epoch["bias"]
 
     frames = md.get_calibrations_metadata(mjds=mjds, calibration="bias")
@@ -1619,7 +1757,7 @@ def create_traces(mjd, epochs=None, cameras=CAMERAS, ring="primary",
         Skip pipeline steps that have already been done, by default True
     """
 
-    epoch = get_calibration_epoch(mjd=mjd, **(epochs or {}).get(mjd, {}))
+    epoch = get_epoch(mjd=mjd, epochs=epochs or {}, epochs_kind="calibration", error_on_missing_mjd=False)
     mjds = epoch["trace"]
 
     frames = md.get_calibrations_metadata(mjds=mjds, calibration="trace")
@@ -1887,7 +2025,7 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
     if not _channels.issubset(set("brz")):
         raise ValueError(f"Invalid value in `channels`: {channels}. Expected a subset of 'brz'")
 
-    epoch = get_calibration_epoch(mjd=mjd, **(epochs or {}).get(mjd, {}))
+    epoch = get_epoch(mjd=mjd, epochs=epochs or {}, epochs_kind="calibration", error_on_missing_mjd=False)
     mjds = epoch["twilight"]
 
     frames = md.get_calibrations_metadata(mjds=mjds, calibration="twilight")
@@ -2098,7 +2236,7 @@ def create_wavelengths(mjd, epochs=None, use_longterm_cals=True, kind="longterm"
         _create_wavelengths_60177(use_longterm_cals=use_longterm_cals, skip_done=skip_done, dry_run=dry_run)
         return
 
-    epoch = get_calibration_epoch(mjd=mjd, **(epochs or {}).get(mjd, {}))
+    epoch = get_epoch(mjd=mjd, epochs=epochs or {}, epochs_kind="calibration", error_on_missing_mjd=False)
     mjds = epoch["wave"]
 
     frames = md.get_calibrations_metadata(mjds=mjds, calibration="wave")
@@ -2272,7 +2410,7 @@ def reduce_nightly_sequence(mjd, use_longterm_cals=False, reject_cr=True, only_c
         create_dome_fiberflats(mjd=mjd, use_longterm_cals=use_longterm_cals, kind="nightly", skip_done=skip_done, dry_run=dry_run)
 
     if "twilight" in only_cals:
-        create_twilight_fiberflats(mjd=mjd, use_longterm_cals=use_longterm_cals, skip_done=skip_done, dry_run=dry_run)
+        create_twilight_fiberflats(mjd=mjd, skip_done=skip_done, dry_run=dry_run)
 
     # if not keep_ancillary:
     #     _clean_ancillary(mjd)
@@ -2365,7 +2503,6 @@ def reduce_longterm_sequence(mjd, epochs=None, use_longterm_cals=True,
             mjd=mjd,
             epochs=epochs,
             cals_mjd=mjd,
-            use_longterm_cals=use_longterm_cals,
             skip_sequence_selection=skip_sequence_selection,
             skip_combination=skip_combination,
             skip_done=skip_done,

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -130,7 +130,7 @@ def _read_ffactors(drpver, channel):
 def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=20.0,
                       fiber_radius=0.01, oversampling_factor=100, quantiles=(5.0, 97.0),
                       groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
-                      fit_gradient=False, label=None, write_table=False, table_dir=None, display_plots=False):
+                      fit_gradient=False, label=None, write_table=False, table_dir=None, overwrite=False, display_plots=False):
     # define label if not given
     label = label or "".join(filter(str.isalnum, norm_stat.__name__))
 
@@ -139,6 +139,8 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
     table_dir = table_dir or "./"
     os.makedirs(table_dir, exist_ok=True)
     table_path = os.path.join(table_dir, f"{name}.csv")
+    if not overwrite and os.path.exists(table_path):
+        return pd.read_csv(table_path)
 
     # grab all relevant DRP products: before/ after fiber flat fielding
     channel_ = "?" if channel == "all" else channel
@@ -210,7 +212,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
     metadata = pd.DataFrame(metadata)
     metadata.sort_values("exposure", inplace=True)
     if write_table:
-        metadata.to_csv(table_path)
+        metadata.to_csv(table_path, index=False)
 
     return metadata
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -2266,6 +2266,8 @@ def reduce_longterm_sequence(mjd, epochs=None, use_longterm_cals=True,
                              counts_thresholds=COUNTS_THRESHOLDS,
                              cent_guess_ncolumns=140, trace_full_ncolumns=40,
                              extract_metadata=False,
+                             skip_sequence_selection=False,
+                             skip_combination=False,
                              skip_done=True, keep_ancillary=False,
                              link_pixelmasks=True,
                              dry_run=False):
@@ -2294,7 +2296,11 @@ def reduce_longterm_sequence(mjd, epochs=None, use_longterm_cals=True,
         Only produce this calibrations, by default {'bias', 'trace', 'wave', 'dome', 'twilight'}
     extract_metadata : bool, optional
         Extract or use cached metadata if exist, by default False (use cache)
-    skip_done : bool
+    skip_sequence_selection : bool, optional
+        Skip calibration sequence selection, by default False
+    skip_combination : bool, optional
+        Skip combination of calibrations into final master frames, by default False
+    skip_done : bool, optional
         Skip pipeline steps that have already been done
     keep_ancillary : bool
         Keep ancillary files, by default False
@@ -2338,7 +2344,15 @@ def reduce_longterm_sequence(mjd, epochs=None, use_longterm_cals=True,
         create_dome_fiberflats(mjd=mjd, cals_mjd=mjd, use_longterm_cals=use_longterm_cals, kind="longterm", skip_done=skip_done, dry_run=dry_run)
 
     if "twilight" in only_cals:
-        create_twilight_fiberflats(mjd=mjd, epochs=epochs, cals_mjd=mjd, use_longterm_cals=use_longterm_cals, skip_done=skip_done, dry_run=dry_run)
+        create_twilight_fiberflats(
+            mjd=mjd,
+            epochs=epochs,
+            cals_mjd=mjd,
+            use_longterm_cals=use_longterm_cals,
+            skip_sequence_selection=skip_sequence_selection,
+            skip_combination=skip_combination,
+            skip_done=skip_done,
+            dry_run=dry_run)
 
     # if not keep_ancillary:
     #     _clean_ancillary(mjd)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -213,6 +213,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
             fiber_radius=fiber_radius,
             oversampling_factor=oversampling_factor,
             coadd_method=coadd_method,
+            norm_method=norm_stat,
             quantiles=quantiles,
             guess_coeffs=[1,0,0,0],
             fixed_coeffs=[3] if fit_gradient else [1, 2, 3],

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -77,7 +77,7 @@ from lvmdrp.core.fit_profile import gaussians, IFUGradient
 
 from lvmdrp.functions import imageMethod as image_tasks
 from lvmdrp.functions import rssMethod as rss_tasks
-from lvmdrp.functions import sky_qa as sky
+from lvmdrp.core import sky
 from lvmdrp.main import start_logging, get_config_options, read_fibermap, reduce_2d, reduce_1d
 from lvmdrp.functions.run_twilights import lvmFlat, to_native_wave, fit_fiberflat, combine_twilight_sequence, fit_skyline_flatfield
 
@@ -103,14 +103,14 @@ FIBER_SMOOTHING_CONFIG = {
 CALIBRATION_EPOCHS_PATH = os.path.join(os.getenv("LVMCORE_DIR"), "calibrations", "calibration-epochs.yaml")
 
 
-def _extract_ffactors(header):
-    channel = header["CCD"][0]
+def _extract_ffactors(channel, header):
     columns = [
         "obstime", "smjd", "tile_id", "exposure", "scira", "scidec", f"{channel} fiberflat grad",
         f"{channel}1 fiberflat corr", f"{channel}2 fiberflat corr", f"{channel}3 fiberflat corr"]
 
     metadata_row = {k.replace(" ", "_"): header.get(k) for k in columns}
-    metadata_sky = sky.create_overview(header)
+    metadata_sky = sky.sky_pars_header(header)
+    metadata_sky = {k.split()[-1].lower().replace("sci_", ""): v[0] for k, v in metadata_sky.items() if "SKYE_" not in k and "SKYW_" not in k}
     metadata_row.update(metadata_sky)
 
     return metadata_row
@@ -155,6 +155,10 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
     metadata = []
     for wframe_path in wframe_paths:
         rss = RSS.from_file(wframe_path)
+
+        if "ON" in [rss._header[lamp] for lamp in ARC_LAMPS + CON_LAMPS]:
+            metadata.append(_extract_ffactors(channel, rss._header))
+            continue
 
         channel_current = rss._header["CCD"][0]
         expnum = rss._header["EXPOSURE"]
@@ -207,7 +211,7 @@ def _measure_ffactors(mjd, drpver, channel, sky_lines=SKYLINES_FIBERFLAT, dwave=
         rss._header[f"HIERARCH {channel.upper()}3 FIBERFLAT CORR"] =  (np.round(factor[2], 5), "fiberflat corr. spec. 3")
 
         # extract flat field factors and additional information
-        metadata.append(_extract_ffactors(rss._header))
+        metadata.append(_extract_ffactors(channel, rss._header))
 
     metadata = pd.DataFrame(metadata)
     metadata.sort_values("exposure", inplace=True)

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -123,7 +123,7 @@ def _read_ffactors(drpver, channel):
     for p in tqdm(frame_paths, desc=f"extracting factors for {drpver = } | {channel = }", ascii=True, unit="exposure"):
         hdr = fits.getheader(p)
 
-        metadata.append(_extract_ffactors(hdr))
+        metadata.append(_extract_ffactors(channel, hdr))
     return pd.DataFrame(metadata)
 
 

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -1819,7 +1819,7 @@ def create_dome_fiberflats(mjd, expnums_ldls=None, expnums_qrtz=None, cals_mjd=N
 
 def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mjd: int = None, use_longterm_cals: bool = True,
                       ref_kind: Union[int, Callable[[np.ndarray, int], np.ndarray]] = bn.nanmedian,
-                      groupby: str = "spec", guess_coeffs: List[int] = [1,0,0,0], fixed_coeffs: List[int] = [0,1,2,3],
+                      groupby: str = "spec", guess_coeffs: List[int] = [1,0,0,0], fixed_coeffs: List[int] = [3],
                       cnorms: Dict[str, float] = SKYLINES_FIBERFLAT, dwave: float = 20.0,
                       smoothing: float = 0.07,
                       interpolate_invalid: bool = True,
@@ -1848,7 +1848,7 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
     guess_coeffs : list[int], optional
         Initial guess for polynomial coefficients in gradient fitting. Defaults to [1,0,0,0].
     fixed_coeffs : list[int], optional
-        Indices of coefficients to fix during fitting. Defaults to [1,2,3].
+        Indices of coefficients to fix during fitting. Defaults to [3].
     cnorms : dict, optional
         Dictionary of normalization wavelengths per channel. Defaults to SKYLINES_FIBERFLAT.
     dwave : float, optional

--- a/python/lvmdrp/functions/run_calseq.py
+++ b/python/lvmdrp/functions/run_calseq.py
@@ -281,7 +281,7 @@ def measure_fiberflat_factors(mjd, drpver, channel, expnums=None, sky_cwaves=SKY
             norm_method=norm_stat,
             quantiles=quantiles,
             guess_coeffs=[1,0,0,0],
-            fixed_coeffs=[3] if fit_gradient else [1, 2, 3],
+            fixed_coeffs=[3] if fit_gradient else [0, 1, 2, 3],
             groupby=groupby, axs=axs, labels=True)
 
         log.info("applying flatfield correction")
@@ -2146,7 +2146,7 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
 
     # decompose twilight spectra into sun continuum and twilight components
     flat_channels = frames.groupby(frames.camera.str.__getitem__(0))
-    for channel in _channels:
+    for channel in sorted(_channels):
         flat_expnums = flat_channels.get_group(channel).groupby("expnum")
         xtwi_paths, fflat_paths, lvmflat_paths = [], [], []
         for expnum in flat_expnums.groups:
@@ -2201,10 +2201,27 @@ def create_twilight_fiberflats(mjd: int, epochs: dict[int, dict] = None, cals_mj
             in_waves=calibs["wave"][channel], in_lsfs=calibs["lsf"][channel])
 
 
-def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epochs, sky_cwaves=SKYLINES_FIBERFLAT, cont_cwaves=CONTINUUM_FIBERFLAT, dwave=10.0,
-                                  fiber_radius=1.0, oversampling_factor=100, quantiles=(5.0, 97.0),
-                                  groupby="spec", coadd_method="fit", norm_stat=lambda x: biweight_location(x, ignore_nan=True),
-                                  fit_gradient=False, use_science=True, skip_done=False, undo_correction=False, display_plots=True, dry_run=False):
+def create_fiberflats_corrections(
+    mjd: int,
+    channel: str,
+    ffactor_epochs: Dict[int, Dict[str, List[int]]],
+    calibration_epochs: Dict[int, Dict[str, List[int]]],
+    sky_cwaves: Dict[str, float] = SKYLINES_FIBERFLAT,
+    cont_cwaves: Dict[str, float] = CONTINUUM_FIBERFLAT,
+    dwave: float = 10.0,
+    fiber_radius: float = 1.0,
+    oversampling_factor: int = 100,
+    quantiles: tuple[float, float] = (5.0, 97.0),
+    groupby: str = "spec",
+    coadd_method: str = "fit",
+    norm_stat: Callable[[np.ndarray], float] = lambda x: biweight_location(x, ignore_nan=True),
+    fit_gradient: bool = True,
+    use_science: bool = True,
+    skip_done: bool = False,
+    undo_correction: bool = False,
+    display_plots: bool = True,
+    dry_run: bool = False,
+) -> None:
     """Create and apply fiberflat correction factors to master twilight flats.
 
     The routine determines the relevant ffactor epoch, removes any existing
@@ -2309,6 +2326,7 @@ def create_fiberflats_corrections(mjd, channel, ffactor_epochs, calibration_epoc
         calibs = get_calib_paths(mjd=mjd, version=drpver, flavors=CALIBRATION_NEEDS["twilight"], epochs=calibration_epochs, from_sandbox=False)
 
         # reduce science/twilight exposures down to wavelength calibration step
+        # TODO: make sure to reduce only camera exposures matching given channel
         reduce_2d(mjds=mjd, calibrations=calibs, expnums=expnums, add_astro=use_science, sub_straylight=True, skip_done=skip_done)
         reduce_1d(mjd=mjd, calibrations=calibs, expnums=expnums, sub_straylight=True, skip_done=skip_done)
 

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -681,9 +681,9 @@ def fit_fiberflat(in_rss, out_flat, out_rss, ref_kind=600, guess_coeffs=[1,2,3,0
     flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", False, "fiberflat skyline-corrected?")
     flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
     for i, factor in enumerate(factors):
-        flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", factor, f"fiberflat factor #{i+1}")
+        flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", np.round(factor, 5), f"fiberflat factor {groupby}{i+1}")
     for i, coeff in enumerate(coeffs):
-        flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", coeff, f"IFU gradient coeff #{i+1}")
+        flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", np.round(coeff, 5), f"IFU gradient coeff #{i+1}")
     flat_g.writeFitsData(out_flat)
     log.info(f"writing flatfielded exposure to {out_rss}")
     (rss_g/flat_g).writeFitsData(out_rss)
@@ -813,10 +813,15 @@ def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwav
     save_fig(fig, out_mflat, to_display=display_plots, figure_path="qa", label="flat_correction")
 
     mflat_corr = mflat * flatfield_corr[:, None]
+    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
+    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
+    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT COADD", coadd_method, "coadding method")
     mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
     mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
     for i, f in enumerate(factor):
-        mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", f, f"{groupby}{i+1} factor")
+        mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", np.round(f, 5), f"fiberflat factor {groupby}{i+1}")
+    for i, c in enumerate(coeffs):
+        mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
     log.info(f"writing corrected master fiberflat to {out_mflat}")
     mflat_corr.writeFitsData(out_mflat)
 

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -315,6 +315,8 @@ def combine_twilight_sequence(in_twilights: list[str], in_fflats: List[str], out
     cwave, dwave = mflat._header[f"{channel} FIBERFLAT CWAVE"], mflat._header[f"{channel} FIBERFLAT DWAVE"]
     groupby = mflat._header[f"{channel} FIBERFLAT GROUPBY"]
     coadd_method = mflat._header[f"{channel} FIBERFLAT COADD"]
+    del mflat._header["*FIBERFLAT GCOEFF?"]
+    del mflat._header["*FIBERFLAT FACTOR?"]
 
     # mask invalid pixels
     mflat._mask |= np.isnan(mflat._data) | (mflat._data <= 0) | np.isinf(mflat._data)
@@ -691,32 +693,52 @@ def fit_fiberflat(in_rss, out_flat, out_rss, ref_kind=600, guess_coeffs=[1,2,3,0
     return flat, flat_g, rss_g, coeffs, factors
 
 def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
-                          quantiles=(5,97), nsigma=1, comb_method="median", sky_fibers_only=False, force_correction=False, display_plots=False):
+                          quantiles=(5,97), nsigma=1, comb_method="median", sky_fibers_only=False, force_correction=False, undo_correction=False,
+                          display_plots=False):
 
     log.info(f"loading master fiberflat at {in_mflat}")
     mflat = RSS.from_file(in_mflat)
     channel = mflat._header["CCD"]
-    coadd_method = mflat._header[f"{channel} FIBERFLAT COADD"]
 
-    # verify groupy
+    is_corrected = mflat._header.get(f"{channel} FIBERFLAT SKYCORR")
+    if is_corrected is None:
+        if not force_correction:
+            warnings.warn("no fiber flat correction information, assuming this is an old version of fiber flats and skipping")
+            return mflat, np.ones(mflat._fibers, dtype="float32")
+
+        warnings.warn("forcing correction on possibly old version of fiber flat")
+        is_corrected = False
+
+    coadd_method = mflat._header.get(f"{channel} FIBERFLAT COADD")
     groupby_hdr = mflat._header.get(f"{channel} FIBERFLAT GROUPBY")
+    # verify groupby parameter and replace it with header value if necessary
     if groupby != groupby_hdr:
-        log.warning(f"requested {groupby = } but header says {groupby_hdr}, assuming header value")
+        warnings.warn(f"requested {groupby = } but header says {groupby_hdr}, assuming header value")
         groupby = groupby_hdr
     fiber_groups = mflat._get_fiber_groups(by=groupby)
+    ngroups = len(set(fiber_groups))
 
-    # skip correction if already done and no force is required
-    # undo correction if done and force is required
-    if mflat._header.get(f"{channel} FIBERFLAT SKYCORR"):
+    if undo_correction and not is_corrected:
+        log.info("no correction applied, nothing to undo")
+        return mflat, np.ones(mflat._fibers, dtype="float32")
+
+    if is_corrected:
+        factors = [mflat._header.get(f"{channel} FIBERFLAT FACTOR{i+1}") for i in range(ngroups)]
+        flatfield_corr = IFUGradient.ifu_factors(factors, fiber_groups)
+        log.info(f"fiber flat already corrected; undoing '{groupby}' correction with: {factors}")
+        mflat /= flatfield_corr[:, None]
+        del mflat._header["*FIBERFLAT GCOEFF?"]
+        del mflat._header["*FIBERFLAT FACTOR?"]
+        mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", False)
+
+        if undo_correction:
+            log.info(f"writing uncorrected master fiberflat to {out_mflat}")
+            mflat.writeFitsData(out_mflat)
+            return mflat, np.ones(mflat._fibers, dtype="float32")
+
         if not force_correction:
-            log.info("fiber flat already corrected using sky lines, skipping")
-            return mflat, np.ones(mflat._fibers, dtype="float")
-        else:
-            factors = list(mflat._header[f"{channel} FIBERFLAT FACTOR?"].values())
-            log.info(f"requested {force_correction = }; undoing '{groupby}' correction with: {factors}")
-            flatfield_corr = IFUGradient.ifu_factors(factors, fiber_groups)
-            mflat /= flatfield_corr[:, None]
-            mflat.setHdrValue("HIERARCH {channel} FIBERFLAT SKYCORR", False)
+            log.info(f"{force_correction = }, nothing to do")
+            return mflat, np.ones(mflat._fibers, dtype="float32")
 
     log.info(f"loading {len(in_sciences)} science exposures")
     sciences = [RSS.from_file(in_science) for in_science in in_sciences]
@@ -813,15 +835,15 @@ def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwav
     save_fig(fig, out_mflat, to_display=display_plots, figure_path="qa", label="flat_correction")
 
     mflat_corr = mflat * flatfield_corr[:, None]
-    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
-    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
-    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT COADD", coadd_method, "coadding method")
-    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
-    mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
+    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
+    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
+    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT COADD", coadd_method, "coadding method")
+    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
+    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT GROUPBY", groupby, "fiber grouping")
     for i, f in enumerate(factor):
-        mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", np.round(f, 5), f"fiberflat factor {groupby}{i+1}")
+        mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT FACTOR{i+1}", np.round(f, 5), f"fiberflat factor {groupby}{i+1}")
     for i, c in enumerate(coeffs):
-        mflat_corr.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
+        mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
     log.info(f"writing corrected master fiberflat to {out_mflat}")
     mflat_corr.writeFitsData(out_mflat)
 

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -26,7 +26,7 @@ from lvmdrp.core.rss import RSS, lvmFrame
 from lvmdrp.core.fluxcal import butter_lowpass_filter
 from lvmdrp.core.fit_profile import IFUGradient
 from lvmdrp.core import dataproducts as dp
-from lvmdrp.core.plot import plt, slit, plot_gradient_fit, plot_flatfield_validation, plot_flat_consistency, create_subplots, save_fig
+from lvmdrp.core.plot import plt, slit, plot_gradient_fit, plot_flat_consistency, save_fig
 from lvmdrp import main as drp
 from astropy import wcs
 from astropy.io import fits
@@ -699,184 +699,68 @@ def fit_fiberflat(in_rss, out_flat, out_rss, ref_kind=600, guess_coeffs=[1,2,3,0
 
     return flat, flat_g, rss_g, coeffs, factors
 
-def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
-                          coadd_method="fit", quantiles=(5,97), nsigma=1, comb_method="median",
-                          sky_fibers_only=False, force_correction=False,
-                          undo_correction=False, display_plots=False):
-
-    log.info(f"loading master fiberflat at {in_mflat}")
+def do_ffactor_correction(in_mflat, coeffs, factor, sky_cwave, dwave, coadd_method, write_output=False):
     mflat = RSS.from_file(in_mflat)
     channel = mflat._header["CCD"]
 
-    is_corrected = mflat._header.get(f"{channel} FIBERFLAT SKYCORR")
-    if is_corrected is None:
-        if not force_correction:
-            warnings.warn("no fiber flat correction information, assuming this is an old version of fiber flats and skipping")
-            return mflat, np.ones(mflat._fibers, dtype="float32")
+    was_corrected = mflat._header.get(f"{channel} FIBERFLAT SKYCORR")
+    groupby = mflat._header.get(f"{channel} FIBERFLAT GROUPBY")
+    fiber_groups = mflat._get_fiber_groups(by=groupby)
 
-        warnings.warn("forcing correction on possibly old version of fiber flat")
-        is_corrected = False
+    if was_corrected:
+        log.info("correction already applied, nothing to do")
+        return mflat, np.ones(mflat._fibers, dtype="float32"), was_corrected
 
-    groupby = mflat._header.get(f"{channel} FIBERFLAT GROUPBY", groupby)
+    flatfield_corr = IFUGradient.ifu_factors(factor, fiber_groups)
+    log.info(f"fiber flat not corrected; doing '{groupby}' correction with: {factor}")
+    mflat *= flatfield_corr[:, None]
+    mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
+    mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
+    mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT COADD", coadd_method, "coadding method")
+    mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
+    mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT GROUPBY", groupby, "fiber grouping")
+    for i, f in enumerate(factor):
+        mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT FACTOR{i+1}", np.round(f, 5), f"fiberflat factor {groupby}{i+1}")
+    for i, c in enumerate(coeffs):
+        mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
+
+    if write_output:
+        log.info(f"writing corrected master fiberflat to {in_mflat}")
+        mflat.writeFitsData(in_mflat)
+
+    return mflat, flatfield_corr, was_corrected
+
+def undo_ffactor_correction(in_mflat, write_output=False):
+
+    mflat = RSS.from_file(in_mflat)
+    channel = mflat._header["CCD"]
+
+    was_corrected = mflat._header.get(f"{channel} FIBERFLAT SKYCORR")
+    groupby = mflat._header.get(f"{channel} FIBERFLAT GROUPBY")
     fiber_groups = mflat._get_fiber_groups(by=groupby)
     ngroups = len(set(fiber_groups))
 
-    if undo_correction and not is_corrected:
+    if was_corrected is None:
+        warnings.warn("no fiber flat correction information, assuming this is an old version of fiber flats and skipping")
+        return mflat, np.ones(mflat._fibers, dtype="float32"), None
+
+    if not was_corrected:
         log.info("no correction applied, nothing to undo")
-        return mflat, np.ones(mflat._fibers, dtype="float32")
+        return mflat, np.ones(mflat._fibers, dtype="float32"), was_corrected
 
-    if is_corrected:
-        factors = [mflat._header.get(f"{channel} FIBERFLAT FACTOR{i+1}") for i in range(ngroups)]
-        flatfield_corr = IFUGradient.ifu_factors(factors, fiber_groups)
-        log.info(f"fiber flat already corrected; undoing '{groupby}' correction with: {factors}")
-        mflat /= flatfield_corr[:, None]
-        del mflat._header[f"{channel} FIBERFLAT CWAVE"]
-        del mflat._header[f"{channel} FIBERFLAT DWAVE"]
-        del mflat._header[f"{channel} FIBERFLAT COADD"]
-        del mflat._header["*FIBERFLAT GCOEFF?"]
-        del mflat._header["*FIBERFLAT FACTOR?"]
-        mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", False)
+    factors = [mflat._header.get(f"{channel} FIBERFLAT FACTOR{i+1}") for i in range(ngroups)]
+    flatfield_corr = IFUGradient.ifu_factors(factors, fiber_groups)
+    log.info(f"fiber flat already corrected; undoing '{groupby}' correction with: {factors}")
+    mflat /= flatfield_corr[:, None]
+    del mflat._header[f"{channel} FIBERFLAT CWAVE"]
+    del mflat._header[f"{channel} FIBERFLAT DWAVE"]
+    del mflat._header[f"{channel} FIBERFLAT COADD"]
+    del mflat._header["*FIBERFLAT GCOEFF?"]
+    del mflat._header["*FIBERFLAT FACTOR?"]
+    mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", False)
 
-        if undo_correction:
-            log.info(f"writing uncorrected master fiberflat to {out_mflat}")
-            mflat.writeFitsData(out_mflat)
-            return mflat, np.ones(mflat._fibers, dtype="float32")
+    if write_output:
+        log.info(f"writing uncorrected master fiberflat to {in_mflat}")
+        mflat.writeFitsData(in_mflat)
 
-        if not force_correction:
-            log.info(f"{force_correction = }, nothing to do")
-            return mflat, np.ones(mflat._fibers, dtype="float32")
-
-    log.info(f"loading {len(in_sciences)} science exposures")
-    sciences = [RSS.from_file(in_science) for in_science in in_sciences]
-
-    if isinstance(sciences, list):
-        log.info(f"fitting sky line correction using {len(sciences)} science frames")
-    elif isinstance(sciences, RSS):
-        log.info(f"fitting sky line correction using a single science exposure: {sciences}")
-        science = [sciences]
-    else:
-        raise TypeError(f"Invalid type for `sciences`: {type(sciences)}. Valid types are lvmdrp.core.rss.RSS and list[lvmdrp.core.rss.RSS]")
-
-    fig = plt.figure(figsize=(14,3*(3+len(sciences))))
-    fig.suptitle(f"Fiber flatfield correction for {channel = } around sky line @ {sky_cwave:.2f} Angstroms", fontsize="xx-large")
-    gs_gra = GridSpec(3+len(sciences), 5, hspace=0.01, wspace=0.01, left=0.07, right=0.99, figure=fig)
-    gs_cor = GridSpec(3+len(sciences), 5, hspace=0.5, wspace=0.01, left=0.07, right=0.99, figure=fig)
-
-    sciences_g, factors = [], []
-    log.info(f"going to process {len(sciences)} science exposures in {channel = }:")
-    for i, science in enumerate(sciences):
-        axs = [fig.add_subplot(gs_gra[i, j]) for j in range(5)]
-
-        x, y, _, coeffs, factor, science_g = science.measure_skyline_flatfield(
-            mflat=mflat, sky_cwave=sky_cwave, cont_cwave=cont_cwave, dwave=dwave,
-            quantiles=None, guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs, groupby=groupby,
-            axs=axs, labels=i==0)
-
-        factors.append(factor)
-        sciences_g.append(science_g)
-
-    factor_mean = np.mean(factors, axis=0)
-    factor_sdev = np.std(factors, axis=0)
-    log.info(f"average factors = {np.round(factor_mean, 4)} +/- {np.round(factor_sdev, 4)}")
-
-    if len(sciences) > 2:
-        zscore = np.abs(np.asarray(factors) - factor_mean) / factor_sdev
-        keep = (zscore <= nsigma).all(axis=1)
-        nkeep = keep.sum()
-        log.info(f"rejecting {len(sciences) - nkeep} outlying (> {nsigma} sigma) science exposures")
-    else:
-        keep = np.ones(len(sciences), dtype="bool")
-        nkeep = keep.sum()
-
-    log.info(f"combining {nkeep} gradient corrected science frames using {comb_method = }")
-    science = RSS()
-    science.combineRSS([science_g for i, science_g in enumerate(sciences_g) if keep[i]], method=comb_method)
-    science.apply_pixelmask()
-
-    log.info(f"measuring continuum @ {cont_cwave:.2f} Angstroms")
-    ax_con = fig.add_subplot(gs_cor[-2, :])
-    ax_con.axvline(sky_cwave, lw=1, ls="--", color="0.2")
-    rejects = science.reject_fibers(cwave=cont_cwave, quantiles=quantiles, ax=ax_con)
-    science._data[rejects, :] = np.nan
-    science._error[rejects, :] = np.nan
-    science._mask[rejects, :] = True
-    log.info(f"rejected {rejects.sum()} fibers outside {quantiles = }")
-
-    log.info(f"validating gradient removal around sky line @ {sky_cwave:.2f} Angstroms")
-    axs = [fig.add_subplot(gs_gra[-3, j]) for j in range(5)]
-    axs[0].set_ylabel("combined exposure", fontsize="large")
-
-    x, y, skyline_slit, coeffs, factor = science.fit_ifu_gradient(cwave=sky_cwave, dwave=dwave, groupby=groupby,
-                                                                  guess_coeffs=guess_coeffs, fixed_coeffs=fixed_coeffs, coadd_method="fit")
-    gradient_res = IFUGradient.ifu_gradient(coeffs, x=x, y=y, normalize=True)
-    factors_final = IFUGradient.ifu_factors(factor, fiber_groups, normalize=True)
-    plot_gradient_fit(science._slitmap, skyline_slit, gradient_res, factors_final, telescope="Sci", marker_size=15, axs=axs, labels=False)
-    log.info(f"all fibers factors       = {np.round(factor, 4)}")
-    log.info(f"residual gradient across = {bn.nanmax(gradient_res)/bn.nanmin(gradient_res):.4f}")
-
-    if sky_fibers_only:
-        log.info(f"measuring sky line @ {sky_cwave:.2f} Angstroms on combined science frame")
-        skyline_slit, x, y = science.fit_lines_slit(cwaves=sky_cwave, dwave=dwave, select_fibers=science._slitmap["targettype"]=="SKY", return_xy=True)
-        skyline_slit /= bn.nanmedian(skyline_slit)
-
-        log.info("calculating spectrograph corrections using only sky fibers")
-        slitmap = science._slitmap
-        factor = np.zeros(3, dtype="float")
-        for i in range(3):
-            factor[i] = bn.nanmedian(skyline_slit[slitmap["spectrographid"]==i+1])
-        log.info(f"sky fiber factors    = {np.round(factor, 4)}")
-
-    flatfield_corr = IFUGradient.ifu_factors(factor, fiber_groups)
-
-    science_corr = science / flatfield_corr[:, None]
-    skyline_slit = science_corr.fit_lines_slit(cwaves=sky_cwave, select_fibers="Sci")
-    fiberids = science_corr._slitmap["fiberid"].data
-    ax_cor = fig.add_subplot(gs_cor[-1, :])
-    ax_cor.set_title("Flatfielded slit of combined frame", loc="left")
-    ax_cor.set_xlabel("Fiber ID", fontsize="large")
-    ax_cor.set_ylabel("Normalized counts", fontsize="large")
-    ax_cor.set_ylim(0.92, 1.08)
-    slit(x=fiberids, y=skyline_slit, data=science_corr._data, ax=ax_cor)
-
-    save_fig(fig, out_mflat, to_display=display_plots, figure_path="qa", label="flat_correction")
-
-    mflat_corr = mflat * flatfield_corr[:, None]
-    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")
-    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT DWAVE", dwave, "norm. window width [Angstrom]")
-    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT COADD", coadd_method, "coadding method")
-    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", True, "fiberflat skyline-corrected?")
-    mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT GROUPBY", groupby, "fiber grouping")
-    for i, f in enumerate(factor):
-        mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT FACTOR{i+1}", np.round(f, 5), f"fiberflat factor {groupby}{i+1}")
-    for i, c in enumerate(coeffs):
-        mflat_corr.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT GCOEFF{i+1}", np.round(c, 5), f"IFU gradient coeff #{i+1}")
-    log.info(f"writing corrected master fiberflat to {out_mflat}")
-    mflat_corr.writeFitsData(out_mflat)
-
-    # plot flatfielding validation on science exposures
-    TEST_WAVES = {
-        "b": [3700, 4200, 4800, 5300],
-        "r": [5900, 6300, 6800, 7200],
-        "z": [7800, 8300, 8900, 9500]
-    }
-    test_cwaves = TEST_WAVES[channel]
-    test_sciences = [science_g / flatfield_corr[:, None] for science_g in sciences_g] + [science_corr]
-
-    fig, axs = create_subplots(
-        to_display=display_plots,
-        nrows=len(test_sciences), ncols=len(test_cwaves),
-        figsize=(4*len(test_cwaves),4*len(test_sciences)),
-        sharex=True, sharey=True, layout="constrained", flatten_axes=False)
-    if axs.ndim == 1:
-        axs = np.atleast_2d(axs).T
-    fig.suptitle(f"validating flat-fielded science exposures in {channel = }", fontsize="xx-large")
-    for i in range(len(test_sciences)):
-        plot_flatfield_validation(fframe=test_sciences[i], cwaves=test_cwaves, dwave=dwave, axs=axs[i], coadd_method=coadd_method)
-        expnum = test_sciences[i]._header["EXPOSURE"]
-        if i == len(test_sciences) - 1:
-            axs[i,0].set_ylabel("combined exposure", fontsize="large")
-        else:
-            axs[i,0].set_ylabel(f"{expnum = }", fontsize="large")
-    save_fig(fig, out_mflat, to_display=display_plots, figure_path="qa", label="fiberflat_validation")
-
-    return mflat_corr, flatfield_corr
+    return mflat, flatfield_corr, was_corrected

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -312,9 +312,10 @@ def combine_twilight_sequence(in_twilights: list[str], in_fflats: List[str], out
     mflat = RSS()
     mflat.combineRSS(fflats, method=comb_method)
     channel = mflat._header["CCD"]
-    cwave, dwave = mflat._header[f"{channel} FIBERFLAT CWAVE"], mflat._header[f"{channel} FIBERFLAT DWAVE"]
-    groupby = mflat._header[f"{channel} FIBERFLAT GROUPBY"]
-    coadd_method = mflat._header[f"{channel} FIBERFLAT COADD"]
+    # clean all factor-related keywords to avoid confusion when correcting mflat later
+    del mflat._header[f"{channel} FIBERFLAT CWAVE"]
+    del mflat._header[f"{channel} FIBERFLAT DWAVE"]
+    del mflat._header[f"{channel} FIBERFLAT COADD"]
     del mflat._header["*FIBERFLAT GCOEFF?"]
     del mflat._header["*FIBERFLAT FACTOR?"]
 
@@ -347,7 +348,12 @@ def combine_twilight_sequence(in_twilights: list[str], in_fflats: List[str], out
     # create lvmFlat objects
     log.info(f"creating lvmTFlat products for {len(twilights)}:")
     lvmflats = []
-    for i, twilight in enumerate(twilights):
+    for i, (fflat, twilight) in enumerate(zip(fflats, twilights)):
+        # collect parameters for fitting factors in twilights
+        cwave, dwave = fflat._header[f"{channel} FIBERFLAT CWAVE"], fflat._header[f"{channel} FIBERFLAT DWAVE"]
+        groupby = fflat._header[f"{channel} FIBERFLAT GROUPBY"]
+        coadd_method = fflat._header[f"{channel} FIBERFLAT COADD"]
+
         expnum = twilight._header["EXPOSURE"]
         twilight.set_wave_trace(mwave)
         twilight.set_lsf_trace(mlsf)
@@ -366,6 +372,7 @@ def combine_twilight_sequence(in_twilights: list[str], in_fflats: List[str], out
         log.info(f"  resampling exposure {expnum = } to rectified wavelength grid")
         lvmflat_r = lvmflat.rectify_wave(wave_range=SPEC_CHANNELS[channel], wave_disp=0.5)
 
+        # fit factors in twilights
         log.info(f"  removing factors with parameters: {cwave = :.2f}, {dwave = :.2f} Angstrom, {coadd_method = } and fibers {groupby = }")
         x, y, z, coeffs, factors = lvmflat_r.fit_ifu_gradient(
             guess_coeffs=[1,0,0,0], fixed_coeffs=[0,1,2,3],
@@ -693,8 +700,9 @@ def fit_fiberflat(in_rss, out_flat, out_rss, ref_kind=600, guess_coeffs=[1,2,3,0
     return flat, flat_g, rss_g, coeffs, factors
 
 def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwave, dwave=8, guess_coeffs=[1,2,3,0], fixed_coeffs=[3], groupby="spec",
-                          quantiles=(5,97), nsigma=1, comb_method="median", sky_fibers_only=False, force_correction=False, undo_correction=False,
-                          display_plots=False):
+                          coadd_method="fit", quantiles=(5,97), nsigma=1, comb_method="median",
+                          sky_fibers_only=False, force_correction=False,
+                          undo_correction=False, display_plots=False):
 
     log.info(f"loading master fiberflat at {in_mflat}")
     mflat = RSS.from_file(in_mflat)
@@ -709,12 +717,7 @@ def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwav
         warnings.warn("forcing correction on possibly old version of fiber flat")
         is_corrected = False
 
-    coadd_method = mflat._header.get(f"{channel} FIBERFLAT COADD")
-    groupby_hdr = mflat._header.get(f"{channel} FIBERFLAT GROUPBY")
-    # verify groupby parameter and replace it with header value if necessary
-    if groupby != groupby_hdr:
-        warnings.warn(f"requested {groupby = } but header says {groupby_hdr}, assuming header value")
-        groupby = groupby_hdr
+    groupby = mflat._header.get(f"{channel} FIBERFLAT GROUPBY", groupby)
     fiber_groups = mflat._get_fiber_groups(by=groupby)
     ngroups = len(set(fiber_groups))
 
@@ -727,6 +730,9 @@ def fit_skyline_flatfield(in_sciences, in_mflat, out_mflat, sky_cwave, cont_cwav
         flatfield_corr = IFUGradient.ifu_factors(factors, fiber_groups)
         log.info(f"fiber flat already corrected; undoing '{groupby}' correction with: {factors}")
         mflat /= flatfield_corr[:, None]
+        del mflat._header[f"{channel} FIBERFLAT CWAVE"]
+        del mflat._header[f"{channel} FIBERFLAT DWAVE"]
+        del mflat._header[f"{channel} FIBERFLAT COADD"]
         del mflat._header["*FIBERFLAT GCOEFF?"]
         del mflat._header["*FIBERFLAT FACTOR?"]
         mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT SKYCORR", False)

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -459,10 +459,13 @@ def get_flatfield(rss, ref_kind=lambda x: biweight_location(x, ignore_nan=True),
         nyq = 1 / (rss._wave[1] - rss._wave[0])
         for ifiber in range(flatfield_r._fibers):
             spec = flatfield.getSpec(ifiber)
-            if spec._mask.all():
-                continue
 
             select = np.isfinite(spec._data)
+            # reject fiber that has half of the pixels masked or
+            # less than `padlen` valid pixels
+            if spec._mask.sum() >= spec._mask.size // 2 or select.sum() <= 15:
+                continue
+
             spec._data[select] = butter_lowpass_filter(median_filter(spec._data[select], 51), smoothing, nyq)
             spec._error[select] = np.sqrt(butter_lowpass_filter(median_filter(spec._error[select]**2, 51), smoothing, nyq))
 

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -677,6 +677,10 @@ def fit_fiberflat(in_rss, out_flat, out_rss, ref_kind=600, guess_coeffs=[1,2,3,0
     flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT COADD", coadd_method, "coadding method")
     flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT SKYCORR", False, "fiberflat skyline-corrected?")
     flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT GROUPBY", groupby, "fiber grouping")
+    for i, factor in enumerate(factors):
+        flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT FACTOR{i+1}", factor, f"fiberflat factor #{i+1}")
+    for i, coeff in enumerate(coeffs):
+        flat_g.setHdrValue(f"HIERARCH {channel} FIBERFLAT GCOEFF{i+1}", coeff, f"IFU gradient coeff #{i+1}")
     flat_g.writeFitsData(out_flat)
     log.info(f"writing flatfielded exposure to {out_rss}")
     (rss_g/flat_g).writeFitsData(out_rss)

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -731,13 +731,12 @@ def do_ffactor_correction(in_mflat, coeffs, factor, sky_cwave, dwave, coadd_meth
 
     was_corrected = mflat._header.get(f"{channel} FIBERFLAT SKYCORR")
     groupby = mflat._header.get(f"{channel} FIBERFLAT GROUPBY")
-    fiber_groups = mflat._get_fiber_groups(by=groupby)
 
     if was_corrected:
         log.info("correction already applied, nothing to do")
         return mflat, np.ones(mflat._fibers, dtype="float32"), was_corrected
 
-    flatfield_corr = IFUGradient.ifu_factors(factor, fiber_groups)
+    _, _, flatfield_corr = mflat.eval_ifu_gradient(coeffs=coeffs, factors=factor, groupby=groupby, normalize=True)
     log.info(f"fiber flat not corrected; doing '{groupby}' correction with: {factor}")
     mflat *= flatfield_corr[:, None]
     mflat.setHdrValue(f"HIERARCH {channel.upper()} FIBERFLAT CWAVE", sky_cwave, "norm. wavelength [Angstrom]")

--- a/python/lvmdrp/functions/run_twilights.py
+++ b/python/lvmdrp/functions/run_twilights.py
@@ -700,6 +700,32 @@ def fit_fiberflat(in_rss, out_flat, out_rss, ref_kind=600, guess_coeffs=[1,2,3,0
     return flat, flat_g, rss_g, coeffs, factors
 
 def do_ffactor_correction(in_mflat, coeffs, factor, sky_cwave, dwave, coadd_method, write_output=False):
+    """Apply fiberflat skyline-factor corrections to a master flat.
+
+    Parameters
+    ----------
+    in_mflat : str or path-like
+        Path to the master fiberflat file to modify.
+    coeffs : sequence of float
+        IFU gradient coefficients used for the correction.
+    factor : sequence of float
+        Per-group fiberflat correction factors to apply.
+    sky_cwave : float
+        Central wavelength used for the correction.
+    dwave : float
+        Wavelength window width used for the correction.
+    coadd_method : str
+        Method used to coadd the spectra when the correction was derived.
+    write_output : bool, optional
+        Whether to overwrite the input master fiberflat file with the corrected
+        data, by default False.
+
+    Returns
+    -------
+    tuple
+        The corrected RSS object, the array of applied flatfield factors, and
+        the previous correction state.
+    """
     mflat = RSS.from_file(in_mflat)
     channel = mflat._header["CCD"]
 
@@ -731,6 +757,22 @@ def do_ffactor_correction(in_mflat, coeffs, factor, sky_cwave, dwave, coadd_meth
     return mflat, flatfield_corr, was_corrected
 
 def undo_ffactor_correction(in_mflat, write_output=False):
+    """Remove previously applied fiberflat skyline-factor corrections.
+
+    Parameters
+    ----------
+    in_mflat : str or path-like
+        Path to the master fiberflat file to modify.
+    write_output : bool, optional
+        Whether to overwrite the input master fiberflat file with the
+        uncorrected data, by default False.
+
+    Returns
+    -------
+    tuple
+        The uncorrected RSS object, the inverse flatfield factors, and the
+        previous correction state.
+    """
 
     mflat = RSS.from_file(in_mflat)
     channel = mflat._header["CCD"]

--- a/python/lvmdrp/utils/paths.py
+++ b/python/lvmdrp/utils/paths.py
@@ -66,32 +66,45 @@ def mjd_from_expnum(expnum: Union[int, str, list, tuple]) -> List[int]:
     return [int(mjd)]
 
 
-def get_calib_paths(mjd, version=None, cameras="*", flavors=CALIBRATION_PRODUCTS, nightly=False, from_sandbox=True, return_mjd=False, only_existing=False):
-    """Returns a dictionary containing paths for calibration frames
+def get_calib_paths(mjd, version=None, cameras="*", flavors=CALIBRATION_PRODUCTS, epochs=None, nightly=False, from_sandbox=True, return_mjd=False, only_existing=False):
+    """Return calibration file paths for a given reduction epoch.
+
+    The helper resolves the most relevant master-calibration MJD for the input
+    MJD and builds a mapping of calibration file paths for the requested
+    cameras and flavors.
 
     Parameters
     ----------
     mjd : int
-        MJD to reduce
+        MJD of the science or calibration frame for which paths are needed.
     version : str, optional
-        Version of the pipeline to pull calibrations from, by default None
-    cameras : list[str]|str, optional
-        List of cameras or wildcard to match, by default '*'
-    flavors : list, tuple or set
-        Only get paths for this calibrations, by default all available flavors
-    nightly : bool
-        Whether get nightly calibration or long-term paths, defaults to False
+        Pipeline version to resolve long-term calibration paths from, by default
+        None.
+    cameras : list[str] | str, optional
+        Camera names or wildcard pattern to match, by default ``"*"``.
+    flavors : list, tuple or set, optional
+        Calibration flavors to include. By default all available flavors are
+        considered.
+    epochs : dict, optional
+        Mapping of epoch MJDs to epoch metadata. When provided, the helper uses
+        the latest epoch boundary that is less than or equal to ``mjd`` to
+        select the calibration MJD.
+    nightly : bool, optional
+        Whether to prefer nightly calibration paths over long-term ones, by
+        default False.
     from_sandbox : bool, optional
-        Fall back option to pull calibrations from sandbox, by default False
+        Whether to resolve calibrations from the sandbox/master directory,
+        by default True.
     return_mjd : bool, optional
-        Return MJD of the selected calibrations, by default False
+        Whether to also return the selected calibration MJD, by default False.
     only_existing : bool, optional
-        Return only existing paths in calibrations dictionary, by default False
+        Whether to return only paths that already exist on disk, by default
+        False.
 
     Returns
     -------
-    calibs : dict[str, dict[str, str]]
-        a dictionary containing calibrations for the given cameras
+    dict[str, dict[str, str]]
+        Calibration path mapping for the requested cameras and flavors.
     """
     if version is None and not from_sandbox:
         raise ValueError(f"You must provide a version string to get calibration paths, {version = } given")
@@ -102,8 +115,13 @@ def get_calib_paths(mjd, version=None, cameras="*", flavors=CALIBRATION_PRODUCTS
     tileid = 11111
     tilegrp = tileid_grp(tileid)
 
-    # get long-term MJDs from sandbox using get_master_mjd, else use given MJD
-    cals_mjd = get_master_mjd(mjd) if from_sandbox else mjd
+    # define calibration MJD: take MJD from sandbox or assume
+    if epochs is None:
+        cals_mjd = get_master_mjd(mjd) if from_sandbox else mjd
+    else:
+        epoch_mjds = sorted(int(cals_mjd) for cals_mjd in epochs.keys())
+        matching_mjds = [cals_mjd for cals_mjd in epoch_mjds if cals_mjd <= int(mjd)]
+        cals_mjd = matching_mjds[-1] if matching_mjds else int(mjd)
 
     # define root path to pixel flats and masks
     # TODO: remove this once sdss-tree are updated with the corresponding species


### PR DESCRIPTION
Implementing better fiber flat corrections. Main changes are:

- Improved (sky) line profile modeling to account for mismatch around line peaks (less peaky than a Gaussian)
- Implemented CLI for bulk testing of fiber flat corrections under different configurations (e.g., fitting IFU gradient or not)
- Implemented fiber flat factor epochs file
- Several other improvements and bugfixes

Fiber flat factors show great stability over the course of 2 years of survey. As a consequence, this PR now implements frozen fiber flat corrections that are only measured after instrument interventions on science frames using sky lines.